### PR TITLE
feature/phase1-essential-pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.2.1",
         "tailwindcss": "^4",
-        "typescript": "^5",
+        "typescript": "5.9.3",
         "webpack-bundle-analyzer": "^4.10.2"
       }
     },
@@ -59,10 +59,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.0.tgz",
-      "integrity": "sha512-RoV8Xs9eNwiDvhv7M+xcL4PWyRyIXRY/FLp3buU4h1EYfdF7unWUy3dOjPqb3C7rMUewIcqwW850PgS8h1o1yg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -89,10 +90,11 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1083,20 +1085,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.1.tgz",
-      "integrity": "sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.26.1",
-        "@typescript-eslint/type-utils": "8.26.1",
-        "@typescript-eslint/utils": "8.26.1",
-        "@typescript-eslint/visitor-keys": "8.26.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1106,22 +1108,33 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.1.tgz",
-      "integrity": "sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.26.1",
-        "@typescript-eslint/types": "8.26.1",
-        "@typescript-eslint/typescript-estree": "8.26.1",
-        "@typescript-eslint/visitor-keys": "8.26.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1131,18 +1144,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
-      "integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.1",
-        "@typescript-eslint/visitor-keys": "8.26.1"
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1152,16 +1188,35 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.1.tgz",
-      "integrity": "sha512-Kcj/TagJLwoY/5w9JGEFV0dclQdyqw9+VMndxOJKtoFSjfZhLXhYjzsQEeyza03rwHx2vFEGvrJWJBXKleRvZg==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.26.1",
-        "@typescript-eslint/utils": "8.26.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1171,15 +1226,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
-      "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1189,19 +1245,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
-      "integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.1",
-        "@typescript-eslint/visitor-keys": "8.26.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1211,53 +1269,40 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1267,15 +1312,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.1.tgz",
-      "integrity": "sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.26.1",
-        "@typescript-eslint/types": "8.26.1",
-        "@typescript-eslint/typescript-estree": "8.26.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1285,18 +1331,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
-      "integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.1",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1304,6 +1351,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
@@ -1907,10 +1967,11 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2976,12 +3037,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/gzip-size": {
@@ -4677,10 +4732,11 @@
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "devOptional": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5101,13 +5157,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5117,10 +5174,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5131,10 +5192,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -5164,10 +5226,11 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
@@ -5279,10 +5342,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.1",
     "tailwindcss": "^4",
-    "typescript": "^5",
+    "typescript": "5.9.3",
     "webpack-bundle-analyzer": "^4.10.2"
   }
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "About - JSON Animation Viewer",
+  description:
+    "JSON Animation Viewer is a free, privacy-focused tool for previewing Lottie JSON animations in your browser. No uploads, no databases — everything runs locally.",
+  alternates: {
+    canonical: "/about",
+  },
+};
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen bg-gray-900">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link
+          href="/"
+          className="text-blue-400 hover:text-blue-300 text-sm mb-8 inline-block transition-colors"
+        >
+          &larr; Back to Home
+        </Link>
+
+        <h1 className="text-4xl font-bold text-white mb-6">About JSON Animation Viewer</h1>
+
+        <div className="prose prose-invert max-w-none space-y-8 text-gray-300 leading-relaxed">
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">What is JSON Animation Viewer?</h2>
+            <p>
+              JSON Animation Viewer is a free, browser-based tool designed to help developers,
+              designers, and animators preview{" "}
+              <strong className="text-white">Lottie JSON animation files</strong> quickly and
+              securely. Whether you&apos;re working on a mobile app, a website, or a design project,
+              our tool lets you instantly visualize your animations without installing any software.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">Why We Built This</h2>
+            <p>
+              Lottie animations have become the standard for adding lightweight, scalable animations
+              to digital products. However, previewing these JSON files typically requires dedicated
+              software or complex development setups. We created JSON Animation Viewer to solve this
+              problem — a simple drag-and-drop tool that works right in your browser.
+            </p>
+            <p className="mt-3">
+              Our goal is to provide the fastest, easiest way to preview Lottie animations with zero
+              friction. No sign-ups, no downloads, no configurations.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">Key Features</h2>
+            <ul className="list-disc pl-6 space-y-3">
+              <li>
+                <strong className="text-white">Instant Preview:</strong> Drop your JSON file and see
+                the animation play immediately. No loading screens, no waiting.
+              </li>
+              <li>
+                <strong className="text-white">100% Privacy:</strong> Your animation files never
+                leave your device. Everything is processed locally in your browser using JavaScript.
+                We have no servers, no databases, and no file storage.
+              </li>
+              <li>
+                <strong className="text-white">Size Detection:</strong> Automatically detects and
+                displays the original dimensions (width &times; height) of your animation, helping
+                you plan your layout.
+              </li>
+              <li>
+                <strong className="text-white">Drag &amp; Drop:</strong> Simply drag your JSON file
+                onto the viewer area, or click the button to select a file from your device.
+              </li>
+              <li>
+                <strong className="text-white">Mobile Friendly:</strong> Works on all devices —
+                desktop, tablet, and mobile. Preview animations on the go.
+              </li>
+              <li>
+                <strong className="text-white">Free Forever:</strong> JSON Animation Viewer is
+                completely free to use with no hidden costs or premium tiers.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">What Are Lottie Animations?</h2>
+            <p>
+              Lottie is an open-source animation format created by Airbnb. It renders animations in
+              real time using JSON data exported from tools like Adobe After Effects (via the
+              Bodymovin plugin). Lottie animations are:
+            </p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>
+                <strong className="text-white">Lightweight:</strong> Much smaller than GIFs or video
+                files
+              </li>
+              <li>
+                <strong className="text-white">Scalable:</strong> Vector-based, so they look sharp
+                at any resolution
+              </li>
+              <li>
+                <strong className="text-white">Interactive:</strong> Can be controlled
+                programmatically (play, pause, reverse, etc.)
+              </li>
+              <li>
+                <strong className="text-white">Cross-Platform:</strong> Supported on iOS, Android,
+                web, and desktop applications
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">Technology</h2>
+            <p>JSON Animation Viewer is built with modern web technologies:</p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>
+                <strong className="text-white">Next.js 15</strong> — React framework for production-grade web apps
+              </li>
+              <li>
+                <strong className="text-white">React 19</strong> — Latest version of the popular UI
+                library
+              </li>
+              <li>
+                <strong className="text-white">Lottie-web</strong> — Official Lottie rendering
+                library by Airbnb
+              </li>
+              <li>
+                <strong className="text-white">Tailwind CSS</strong> — Utility-first CSS framework
+              </li>
+              <li>
+                <strong className="text-white">TypeScript</strong> — Static type checking for
+                reliability
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">Open Source</h2>
+            <p>
+              JSON Animation Viewer is open source. You can view the source code, report issues, or
+              contribute on our{" "}
+              <a
+                href="https://github.com/lbo728/json-animation-viewer"
+                className="text-blue-400 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub repository
+              </a>.
+              Contributions, bug reports, and feature requests are always welcome.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">Contact</h2>
+            <p>
+              Have questions, feedback, or suggestions? Feel free to open an issue on our{" "}
+              <a
+                href="https://github.com/lbo728/json-animation-viewer/issues"
+                className="text-blue-400 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub Issues page
+              </a>{" "}
+              or reach out through the repository.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import GoogleAdSense from "@/components/GoogleAdsense";
 import JsonLd from "./JsonLd";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -89,7 +90,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        {children}
+        <div className="flex flex-col min-h-screen">
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
         <GoogleAdSense />
         <JsonLd />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,66 +148,151 @@ export default function Home() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-6 bg-gray-900">
-      <h1 className="text-[40px] md:text-[48px] lg:text-[72px] font-extrabold text-white mb-2 text-center">
-        JSON Animation Viewer
-      </h1>
-      <h2 className="text-[16px] md:text-[18px] lg:text-[20px] text-gray-300 mb-2 text-center">
-        Easily preview your JSON animations by dragging them here!
-      </h2>
-      <p className="text-[12px] md:text-[14px] lg:text-[16px] text-gray-400 mb-6 text-center">
-        Your JSON will not be stored on this site. You can rest assured as this
-        site has no database.
-      </p>
-
-      <label className="mb-4 w-fit text-center">
-        {fileName && (
-          <span className="mt-2 mr-2 text-gray-200">{fileName}</span>
-        )}
-        <input
-          type="file"
-          accept=".json"
-          onChange={handleFileUpload}
-          className="hidden"
-          ref={fileInputRef}
-        />
-        <button
-          className="relative bg-opacity-30 bg-gray-800 text-white px-[48px] py-3 rounded-lg shadow-md hover:bg-opacity-50 transition-all w-full md:w-auto backdrop-blur-md border border-gray-700 overflow-hidden cursor-pointer hover:bg-gray-900"
-          onClick={handleButtonClick}
-          aria-label="Select JSON file"
-        >
-          Select File
-          <span className="absolute inset-0 w-full h-full border-2 border-transparent rounded-lg animate-pulse"></span>
-        </button>
-      </label>
-      <div
-        ref={containerRef}
-        className="border border-gray-700 w-full max-w-md h-96 flex items-center justify-center mb-8 bg-gray-800 rounded-lg shadow-lg"
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        aria-label="Drop zone for JSON animation files"
-        role="region"
-      >
-        {!animationData && (
-          <p className="text-gray-400">Drag and drop your JSON here!</p>
-        )}
-      </div>
-      {lottie && animationData && (
-        <Suspense fallback={<LoadingFallback />}>
-          <AnimationContainer
-            lottie={lottie}
-            animationData={animationData}
-            containerRef={containerRef as React.RefObject<HTMLDivElement>}
-            setAnimationSize={setAnimationSize}
-          />
-        </Suspense>
-      )}
-      <div className="mt-4">
-        <p className="animation-size text-gray-300">
-          Animation Size(include viewport): {animationSize.width} x{" "}
-          {animationSize.height}
+    <div className="flex flex-col items-center bg-gray-900">
+      <section className="flex flex-col items-center justify-center min-h-screen p-6 w-full">
+        <h1 className="text-[40px] md:text-[48px] lg:text-[72px] font-extrabold text-white mb-2 text-center">
+          JSON Animation Viewer
+        </h1>
+        <h2 className="text-[16px] md:text-[18px] lg:text-[20px] text-gray-300 mb-2 text-center">
+          Easily preview your JSON animations by dragging them here!
+        </h2>
+        <p className="text-[12px] md:text-[14px] lg:text-[16px] text-gray-400 mb-6 text-center">
+          Your JSON will not be stored on this site. You can rest assured as this
+          site has no database.
         </p>
-      </div>
+      <label className="mb-4 w-fit text-center">
+          {fileName && (
+            <span className="mt-2 mr-2 text-gray-200">{fileName}</span>
+          )}
+          <input
+            type="file"
+            accept=".json"
+            onChange={handleFileUpload}
+            className="hidden"
+            ref={fileInputRef}
+          />
+          <button
+            className="relative bg-opacity-30 bg-gray-800 text-white px-[48px] py-3 rounded-lg shadow-md hover:bg-opacity-50 transition-all w-full md:w-auto backdrop-blur-md border border-gray-700 overflow-hidden cursor-pointer hover:bg-gray-900"
+            onClick={handleButtonClick}
+            aria-label="Select JSON file"
+          >
+            Select File
+            <span className="absolute inset-0 w-full h-full border-2 border-transparent rounded-lg animate-pulse"></span>
+          </button>
+        </label>
+        <div
+          ref={containerRef}
+          className="border border-gray-700 w-full max-w-md h-96 flex items-center justify-center mb-8 bg-gray-800 rounded-lg shadow-lg"
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          aria-label="Drop zone for JSON animation files"
+          role="region"
+        >
+          {!animationData && (
+            <p className="text-gray-400">Drag and drop your JSON here!</p>
+          )}
+        </div>
+        {lottie && animationData && (
+          <Suspense fallback={<LoadingFallback />}>
+            <AnimationContainer
+              lottie={lottie}
+              animationData={animationData}
+              containerRef={containerRef as React.RefObject<HTMLDivElement>}
+              setAnimationSize={setAnimationSize}
+            />
+          </Suspense>
+        )}
+        <div className="mt-4">
+          <p className="animation-size text-gray-300">
+            Animation Size(include viewport): {animationSize.width} x{" "}
+            {animationSize.height}
+          </p>
+        </div>
+      </section>
+
+      <section className="w-full max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-3xl font-bold text-white text-center mb-12">
+          How It Works
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="text-center">
+            <div className="w-16 h-16 mx-auto mb-4 bg-blue-500/10 rounded-full flex items-center justify-center">
+              <span className="text-3xl">1</span>
+            </div>
+            <h3 className="text-xl font-semibold text-white mb-2">Select or Drop</h3>
+            <p className="text-gray-400">
+              Click the &quot;Select File&quot; button or drag and drop your Lottie JSON file onto the viewer area. We support all standard Lottie JSON formats.
+            </p>
+          </div>
+          <div className="text-center">
+            <div className="w-16 h-16 mx-auto mb-4 bg-blue-500/10 rounded-full flex items-center justify-center">
+              <span className="text-3xl">2</span>
+            </div>
+            <h3 className="text-xl font-semibold text-white mb-2">Instant Preview</h3>
+            <p className="text-gray-400">
+              Your animation renders immediately in the browser. No server processing, no waiting — everything happens locally on your device.
+            </p>
+          </div>
+          <div className="text-center">
+            <div className="w-16 h-16 mx-auto mb-4 bg-blue-500/10 rounded-full flex items-center justify-center">
+              <span className="text-3xl">3</span>
+            </div>
+            <h3 className="text-xl font-semibold text-white mb-2">Check Dimensions</h3>
+            <p className="text-gray-400">
+              View the original animation dimensions (width × height) to help plan your implementation and ensure pixel-perfect integration.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="w-full max-w-5xl mx-auto px-6 py-16 border-t border-gray-800">
+        <h2 className="text-3xl font-bold text-white text-center mb-12">
+          Why Choose JSON Animation Viewer?
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="bg-gray-800/50 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-xl font-semibold text-white mb-3">🔒 Complete Privacy</h3>
+            <p className="text-gray-400 leading-relaxed">
+              Unlike other tools that upload your files to their servers, JSON Animation Viewer processes everything locally in your browser. Your animation data never leaves your device — we have no servers and no databases.
+            </p>
+          </div>
+          <div className="bg-gray-800/50 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-xl font-semibold text-white mb-3">⚡ Lightning Fast</h3>
+            <p className="text-gray-400 leading-relaxed">
+              Powered by lottie-web, the official rendering library by Airbnb, your animations play instantly with smooth performance. No loading spinners, no processing delays.
+            </p>
+          </div>
+          <div className="bg-gray-800/50 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-xl font-semibold text-white mb-3">📱 Works Everywhere</h3>
+            <p className="text-gray-400 leading-relaxed">
+              Whether you are on a desktop, tablet, or mobile phone, JSON Animation Viewer works seamlessly across all devices and modern browsers. Preview your animations on the go.
+            </p>
+          </div>
+          <div className="bg-gray-800/50 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-xl font-semibold text-white mb-3">🎯 Developer Friendly</h3>
+            <p className="text-gray-400 leading-relaxed">
+              Built for developers and designers who work with Lottie animations daily. Instantly check dimensions, preview animations, and verify your JSON files before integrating them into your projects.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="w-full max-w-3xl mx-auto px-6 py-16 border-t border-gray-800">
+        <h2 className="text-3xl font-bold text-white text-center mb-6">
+          What Are Lottie Animations?
+        </h2>
+        <div className="text-gray-400 leading-relaxed space-y-4">
+          <p>
+            Lottie is an open-source animation file format that renders vector-based animations in real time. Created by Airbnb, Lottie animations are exported as JSON data from tools like Adobe After Effects using the Bodymovin plugin.
+          </p>
+          <p>
+            Unlike GIFs or videos, Lottie animations are incredibly lightweight (often under 10KB), fully scalable without quality loss, and can be controlled programmatically — making them the preferred choice for modern app and web development.
+          </p>
+          <p>
+            Lottie animations are widely used across iOS, Android, React Native, and web platforms. Major companies including Airbnb, Google, Uber, and Disney use Lottie animations to create engaging user interfaces and micro-interactions.
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - JSON Animation Viewer",
+  description:
+    "Learn how JSON Animation Viewer handles your data. We process everything locally in your browser — no data is uploaded or stored on our servers.",
+  alternates: {
+    canonical: "/privacy",
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gray-900">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link
+          href="/"
+          className="text-blue-400 hover:text-blue-300 text-sm mb-8 inline-block transition-colors"
+        >
+          &larr; Back to Home
+        </Link>
+
+        <h1 className="text-4xl font-bold text-white mb-2">Privacy Policy</h1>
+        <p className="text-gray-400 text-sm mb-10">Last updated: February 2026</p>
+
+        <div className="prose prose-invert max-w-none space-y-8 text-gray-300 leading-relaxed">
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">1. Introduction</h2>
+            <p>
+              Welcome to JSON Animation Viewer (&quot;we&quot;, &quot;us&quot;, or &quot;our&quot;). We are committed to protecting
+              your privacy. This Privacy Policy explains how we handle information when you use our
+              website at{" "}
+              <a
+                href="https://json-animation-viewer.vercel.app"
+                className="text-blue-400 hover:underline"
+              >
+                json-animation-viewer.vercel.app
+              </a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">2. Data Processing</h2>
+            <p>
+              <strong className="text-white">All processing happens locally in your browser.</strong>{" "}
+              When you upload a JSON animation file to our tool, the file is read and rendered
+              entirely on your device using JavaScript. Your animation data is never uploaded to our
+              servers, stored in any database, or transmitted to any third party.
+            </p>
+            <p className="mt-3">
+              We do not have a backend server or database. JSON Animation Viewer is a static
+              client-side web application hosted on Vercel.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">3. Information We Collect</h2>
+            <p>We may collect the following types of information:</p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>
+                <strong className="text-white">Usage Analytics:</strong> Basic, anonymized analytics
+                data such as page views, browser type, device type, and approximate geographic
+                location (country level). This data is collected through standard web analytics and
+                does not identify individual users.
+              </li>
+              <li>
+                <strong className="text-white">Cookies:</strong> We may use cookies for analytics
+                and advertising purposes. You can control cookie preferences through your browser
+                settings.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">4. Advertising (Google AdSense)</h2>
+            <p>
+              We may display advertisements through Google AdSense or similar advertising networks.
+              These third-party vendors may use cookies and similar technologies to serve ads based
+              on your prior visits to this and other websites.
+            </p>
+            <p className="mt-3">
+              Google&apos;s use of advertising cookies enables it and its partners to serve ads based on
+              your visit to our site and/or other sites on the Internet. You may opt out of
+              personalized advertising by visiting{" "}
+              <a
+                href="https://www.google.com/settings/ads"
+                className="text-blue-400 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Google Ads Settings
+              </a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">5. Third-Party Services</h2>
+            <p>We use the following third-party services:</p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>
+                <strong className="text-white">Vercel:</strong> Hosting and content delivery
+              </li>
+              <li>
+                <strong className="text-white">Google AdSense:</strong> Advertising (may use cookies)
+              </li>
+              <li>
+                <strong className="text-white">Google Search Console:</strong> Website performance monitoring
+              </li>
+            </ul>
+            <p className="mt-3">
+              Each of these services has its own privacy policy governing data collection and usage.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">6. Data Retention</h2>
+            <p>
+              Since we do not collect personal data or store user files, there is no user data to
+              retain. Analytics data is retained only as long as necessary for improving our service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">7. Your Rights</h2>
+            <p>You have the right to:</p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>Disable cookies through your browser settings</li>
+              <li>Opt out of personalized advertising</li>
+              <li>Use our tool without providing any personal information</li>
+              <li>Contact us with any privacy-related concerns</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">8. Children&apos;s Privacy</h2>
+            <p>
+              Our service is not directed at children under the age of 13. We do not knowingly
+              collect personal information from children.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">9. Changes to This Policy</h2>
+            <p>
+              We may update this Privacy Policy from time to time. Any changes will be posted on this
+              page with an updated revision date.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">10. Contact Us</h2>
+            <p>
+              If you have any questions about this Privacy Policy, please contact us through our{" "}
+              <a
+                href="https://github.com/lbo728/json-animation-viewer"
+                className="text-blue-400 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub repository
+              </a>.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,50 @@
 import { MetadataRoute } from "next";
 
+const BASE_URL = "https://json-animation-viewer.vercel.app";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://json-animation-viewer.vercel.app",
+      url: BASE_URL,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
+    },
+    {
+      url: `${BASE_URL}/about`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/guide`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/faq`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/terms`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
     },
   ];
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - JSON Animation Viewer",
+  description:
+    "Terms of Service for JSON Animation Viewer. Understand the terms and conditions for using our free Lottie JSON animation preview tool.",
+  alternates: {
+    canonical: "/terms",
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gray-900">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link
+          href="/"
+          className="text-blue-400 hover:text-blue-300 text-sm mb-8 inline-block transition-colors"
+        >
+          &larr; Back to Home
+        </Link>
+
+        <h1 className="text-4xl font-bold text-white mb-2">Terms of Service</h1>
+        <p className="text-gray-400 text-sm mb-10">Last updated: February 2026</p>
+
+        <div className="prose prose-invert max-w-none space-y-8 text-gray-300 leading-relaxed">
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">1. Acceptance of Terms</h2>
+            <p>
+              By accessing and using JSON Animation Viewer (&quot;the Service&quot;), available at{" "}
+              <a
+                href="https://json-animation-viewer.vercel.app"
+                className="text-blue-400 hover:underline"
+              >
+                json-animation-viewer.vercel.app
+              </a>
+              , you agree to be bound by these Terms of Service. If you do not agree with any part of
+              these terms, please do not use the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">2. Description of Service</h2>
+            <p>
+              JSON Animation Viewer is a free, client-side web application that allows users to
+              preview Lottie JSON animation files directly in their browser. The Service processes
+              all animation data locally on your device without uploading, storing, or transmitting
+              your files to any server.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">3. Use of the Service</h2>
+            <p>You agree to use the Service only for lawful purposes. You shall not:</p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>Use the Service in any way that violates applicable laws or regulations</li>
+              <li>Attempt to interfere with, compromise, or disrupt the Service</li>
+              <li>
+                Use automated systems or software to extract data from the Service (scraping)
+              </li>
+              <li>Upload files that contain malicious code or are designed to exploit vulnerabilities</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">4. Intellectual Property</h2>
+            <p>
+              The Service, including its original content, features, and functionality, is owned by
+              JSON Animation Viewer and is protected by international copyright and other
+              intellectual property laws.
+            </p>
+            <p className="mt-3">
+              Any animation files you upload remain your property. We do not claim any ownership
+              over user-uploaded content, and as stated in our Privacy Policy, your files are never
+              stored on our servers.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">5. Disclaimer of Warranties</h2>
+            <p>
+              The Service is provided &quot;as is&quot; and &quot;as available&quot; without any warranties of any kind,
+              either express or implied, including but not limited to:
+            </p>
+            <ul className="list-disc pl-6 mt-3 space-y-2">
+              <li>Warranties of merchantability or fitness for a particular purpose</li>
+              <li>Warranties that the Service will be uninterrupted, error-free, or secure</li>
+              <li>Warranties regarding the accuracy or reliability of any results obtained through the Service</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">6. Limitation of Liability</h2>
+            <p>
+              In no event shall JSON Animation Viewer, its creators, or contributors be liable for
+              any indirect, incidental, special, consequential, or punitive damages arising out of
+              or related to your use of the Service. This includes, without limitation, damages for
+              loss of profits, data, or other intangible losses.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">7. Third-Party Content</h2>
+            <p>
+              The Service may contain links to third-party websites or display advertisements from
+              third-party advertising networks. We are not responsible for the content, privacy
+              policies, or practices of these third-party services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">8. Modifications to Service</h2>
+            <p>
+              We reserve the right to modify, suspend, or discontinue the Service (or any part
+              thereof) at any time without prior notice. We shall not be liable to you or any third
+              party for any modification, suspension, or discontinuance of the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">9. Changes to Terms</h2>
+            <p>
+              We reserve the right to update these Terms of Service at any time. Changes will be
+              effective immediately upon posting to this page. Your continued use of the Service
+              after any changes constitutes acceptance of the new Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">10. Governing Law</h2>
+            <p>
+              These Terms shall be governed by and construed in accordance with the laws of the
+              Republic of Korea, without regard to its conflict of law provisions.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold text-white mb-3">11. Contact</h2>
+            <p>
+              If you have any questions about these Terms of Service, please reach out through our{" "}
+              <a
+                href="https://github.com/lbo728/json-animation-viewer"
+                className="text-blue-400 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub repository
+              </a>.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="w-full border-t border-gray-800 bg-gray-900 mt-auto">
+      <div className="max-w-5xl mx-auto px-6 py-10">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {/* Brand */}
+          <div>
+            <h3 className="text-white font-bold text-lg mb-3">JSON Animation Viewer</h3>
+            <p className="text-gray-400 text-sm leading-relaxed">
+              A free online tool to preview Lottie JSON animations instantly. Drag and drop your files — no uploads, no databases, completely private.
+            </p>
+          </div>
+
+          {/* Navigation */}
+          <div>
+            <h4 className="text-white font-semibold text-sm uppercase tracking-wider mb-3">Pages</h4>
+            <ul className="space-y-2">
+              <li>
+                <Link href="/" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  Home
+                </Link>
+              </li>
+              <li>
+                <Link href="/about" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  About
+                </Link>
+              </li>
+              <li>
+                <Link href="/guide" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  How to Use
+                </Link>
+              </li>
+              <li>
+                <Link href="/faq" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  FAQ
+                </Link>
+              </li>
+              <li>
+                <Link href="/blog" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  Blog
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          {/* Legal */}
+          <div>
+            <h4 className="text-white font-semibold text-sm uppercase tracking-wider mb-3">Legal</h4>
+            <ul className="space-y-2">
+              <li>
+                <Link href="/privacy" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link href="/terms" className="text-gray-400 hover:text-white text-sm transition-colors">
+                  Terms of Service
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-800 mt-8 pt-6 text-center">
+          <p className="text-gray-500 text-xs">
+            &copy; {new Date().getFullYear()} JSON Animation Viewer. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## 📌 Summary

> Google 애드센스 승인을 위한 필수 정적 페이지 및 콘텐츠 확장 (Phase 1)

## 📋 Changes

- `./src/app/privacy/page.tsx`: Privacy Policy 페이지 추가 (10개 섹션, AdSense/쿠키 정책 포함)
- `./src/app/terms/page.tsx`: Terms of Service 페이지 추가 (11개 섹션)
- `./src/app/about/page.tsx`: About 페이지 추가 (서비스 소개, 기능, Lottie 설명, 기술 스택, 오픈소스 안내)
- `./src/components/Footer.tsx`: 사이트 전체 푸터 네비게이션 컴포넌트 (3컬럼: 브랜드, 페이지 링크, 법적 링크)
- `./src/app/layout.tsx`: 레이아웃에 Footer 추가, flex 구조로 전환
- `./src/app/page.tsx`: 메인 페이지에 How It Works, Why Choose Us, What Are Lottie Animations 섹션 추가
- `./src/app/sitemap.ts`: 7개 URL로 확장 (/, /about, /guide, /faq, /blog, /privacy, /terms)

## 🧠 Context & Background

애드센스 신청이 "게시자 콘텐츠가 없는 화면에 Google 게재 광고" 사유로 거절됨.
원인: 단일 페이지 + 텍스트 콘텐츠 부족. 이 PR은 필수 법적 페이지, 소개 페이지, 메인 페이지 콘텐츠 확장을 포함.

## ✅ How to Test

1. `npm run build` — 빌드 성공 확인 (11개 정적 페이지 생성)
2. `/privacy`, `/terms`, `/about` 경로 접근 확인
3. 모든 페이지에서 Footer 네비게이션 표시 확인
4. 메인 페이지 스크롤 시 How It Works, Why Choose Us, Lottie 소개 섹션 확인

## 🔗 Related Issues

- Related: Google AdSense 재승인을 위한 사이트 구조 개선