### PR TITLE
feature/add-copyright-attribution

### DIFF
--- a/src/app/JsonLd.tsx
+++ b/src/app/JsonLd.tsx
@@ -15,8 +15,9 @@ export default function JsonLd() {
       availability: "https://schema.org/InStock",
     },
     author: {
-      "@type": "Organization",
-      name: "JSON Animation Viewer Team",
+      "@type": "Person",
+      name: "lbo728",
+      url: "https://github.com/lbo728",
     },
     screenshot: "https://json-animation-viewer.vercel.app/og-image.png",
     softwareVersion: "1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,8 +30,8 @@ export const metadata: Metadata = {
     "Easily preview your JSON animations with our user-friendly JSON Animation Viewer. Drag and drop your JSON files to see them in action instantly!",
   keywords:
     "JSON, 애니메이션, 뷰어, json animation viewer, json viewer, json 미리보기, Lottie, 미리보기, JSON 미리보기, lottie viewer, animation preview",
-  authors: [{ name: "JSON Animation Viewer Team" }],
-  creator: "JSON Animation Viewer Team",
+  authors: [{ name: "lbo728", url: "https://github.com/lbo728" }],
+  creator: "lbo728",
   publisher: "JSON Animation Viewer",
   formatDetection: {
     email: false,

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -65,7 +65,16 @@ export default function Footer() {
 
         <div className="border-t border-gray-800 mt-8 pt-6 text-center">
           <p className="text-gray-500 text-xs">
-            &copy; {new Date().getFullYear()} JSON Animation Viewer. All rights reserved.
+            &copy; {new Date().getFullYear()}{" "}
+            <a
+              href="https://github.com/lbo728"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-400 hover:text-white transition-colors"
+            >
+              lbo728
+            </a>
+            . All rights reserved.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 📌 Summary

> Footer, 메타데이터, JSON-LD에 lbo728 저작권 표시 및 GitHub 프로필 링크 추가

## 📋 Changes

- `./src/components/Footer.tsx`: 저작권 텍스트를 "JSON Animation Viewer" → "lbo728"으로 변경, GitHub 프로필 링크 추가
- `./src/app/layout.tsx`: authors 메타데이터를 "JSON Animation Viewer Team" → "lbo728" (GitHub URL 포함)으로 변경, creator도 동일하게 변경
- `./src/app/JsonLd.tsx`: author를 Organization → Person 타입으로 변경, name을 "lbo728", GitHub URL 추가

## 🧠 Context & Background

AdSense 승인을 위한 사이트 개선 과정에서 저작권 표시가 일반적인 팀명으로 되어 있어 실제 소유자 정보가 드러나지 않았음. Google은 사이트 소유자 정보를 명확히 하는 것을 권장하며, 개인 개발자 프로젝트에서 실명/계정명을 노출하는 것이 신뢰도에 도움됨.

## ✅ How to Test

1. `npx next build` 실행하여 빌드 성공 확인
2. `npm run dev`로 로컬 서버 실행
3. 모든 페이지 하단 Footer에서 "© 2026 lbo728" 표시 확인
4. "lbo728" 클릭 시 https://github.com/lbo728 으로 이동 확인
5. 페이지 소스에서 JSON-LD의 author가 Person/lbo728으로 되어 있는지 확인

## 🔗 Related Issues

- Related: #3 (Phase 1), #4 (Phase 2), #5 (Phase 3)