### PR TITLE
feature/fix-seo-canonical-indexing

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `/${locale}/about`,
-      languages: { en: "/en/about", ko: "/ko/about" },
+      canonical: locale === "en" ? "/about" : `/${locale}/about`,
+      languages: { en: "/about", ko: "/ko/about" },
     },
   };
 }

--- a/src/app/[locale]/blog/best-lottie-resources/page.tsx
+++ b/src/app/[locale]/blog/best-lottie-resources/page.tsx
@@ -10,8 +10,8 @@ export async function generateMetadata({params}: {params: Promise<{locale: strin
     title: t('title'),
     description: t('description'),
     alternates: {
-      canonical: `/${locale}/blog/best-lottie-resources`,
-      languages: { en: '/en/blog/best-lottie-resources', ko: '/ko/blog/best-lottie-resources' },
+      canonical: locale === 'en' ? '/blog/best-lottie-resources' : `/${locale}/blog/best-lottie-resources`,
+      languages: { en: '/blog/best-lottie-resources', ko: '/ko/blog/best-lottie-resources' },
     },
     openGraph: {
       type: "article",

--- a/src/app/[locale]/blog/how-to-create-lottie-animation/page.tsx
+++ b/src/app/[locale]/blog/how-to-create-lottie-animation/page.tsx
@@ -10,8 +10,8 @@ export async function generateMetadata({params}: {params: Promise<{locale: strin
     title: t('title'),
     description: t('description'),
     alternates: {
-      canonical: `/${locale}/blog/how-to-create-lottie-animation`,
-      languages: { en: '/en/blog/how-to-create-lottie-animation', ko: '/ko/blog/how-to-create-lottie-animation' },
+      canonical: locale === 'en' ? '/blog/how-to-create-lottie-animation' : `/${locale}/blog/how-to-create-lottie-animation`,
+      languages: { en: '/blog/how-to-create-lottie-animation', ko: '/ko/blog/how-to-create-lottie-animation' },
     },
     openGraph: {
       type: "article",

--- a/src/app/[locale]/blog/json-animation-tutorial/page.tsx
+++ b/src/app/[locale]/blog/json-animation-tutorial/page.tsx
@@ -10,8 +10,8 @@ export async function generateMetadata({params}: {params: Promise<{locale: strin
     title: t('title'),
     description: t('description'),
     alternates: {
-      canonical: `/${locale}/blog/json-animation-tutorial`,
-      languages: { en: '/en/blog/json-animation-tutorial', ko: '/ko/blog/json-animation-tutorial' },
+      canonical: locale === 'en' ? '/blog/json-animation-tutorial' : `/${locale}/blog/json-animation-tutorial`,
+      languages: { en: '/blog/json-animation-tutorial', ko: '/ko/blog/json-animation-tutorial' },
     },
     openGraph: {
       type: "article",

--- a/src/app/[locale]/blog/lottie-vs-gif/page.tsx
+++ b/src/app/[locale]/blog/lottie-vs-gif/page.tsx
@@ -10,8 +10,8 @@ export async function generateMetadata({params}: {params: Promise<{locale: strin
     title: t('title'),
     description: t('description'),
     alternates: {
-      canonical: `/${locale}/blog/lottie-vs-gif`,
-      languages: { en: '/en/blog/lottie-vs-gif', ko: '/ko/blog/lottie-vs-gif' },
+      canonical: locale === 'en' ? '/blog/lottie-vs-gif' : `/${locale}/blog/lottie-vs-gif`,
+      languages: { en: '/blog/lottie-vs-gif', ko: '/ko/blog/lottie-vs-gif' },
     },
     openGraph: {
       type: "article",

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `/${locale}/blog`,
-      languages: { en: "/en/blog", ko: "/ko/blog" },
+      canonical: locale === "en" ? "/blog" : `/${locale}/blog`,
+      languages: { en: "/blog", ko: "/ko/blog" },
     },
   };
 }

--- a/src/app/[locale]/blog/what-is-lottie/page.tsx
+++ b/src/app/[locale]/blog/what-is-lottie/page.tsx
@@ -10,8 +10,8 @@ export async function generateMetadata({params}: {params: Promise<{locale: strin
     title: t('title'),
     description: t('description'),
     alternates: {
-      canonical: `/${locale}/blog/what-is-lottie`,
-      languages: { en: '/en/blog/what-is-lottie', ko: '/ko/blog/what-is-lottie' },
+      canonical: locale === 'en' ? '/blog/what-is-lottie' : `/${locale}/blog/what-is-lottie`,
+      languages: { en: '/blog/what-is-lottie', ko: '/ko/blog/what-is-lottie' },
     },
     openGraph: {
       type: "article",

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `/${locale}/faq`,
-      languages: { en: "/en/faq", ko: "/ko/faq" },
+      canonical: locale === "en" ? "/faq" : `/${locale}/faq`,
+      languages: { en: "/faq", ko: "/ko/faq" },
     },
   };
 }

--- a/src/app/[locale]/guide/page.tsx
+++ b/src/app/[locale]/guide/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `/${locale}/guide`,
-      languages: { en: "/en/guide", ko: "/ko/guide" },
+      canonical: locale === "en" ? "/guide" : `/${locale}/guide`,
+      languages: { en: "/guide", ko: "/ko/guide" },
     },
   };
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -55,9 +55,9 @@ export async function generateMetadata({
     },
     metadataBase: new URL("https://json-animation-viewer.com"),
     alternates: {
-      canonical: `/${locale}`,
+      canonical: locale === "en" ? "/" : `/${locale}`,
       languages: {
-        en: "/en",
+        en: "/",
         ko: "/ko",
       },
     },

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -12,8 +12,8 @@ export async function generateMetadata({
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `/${locale}/privacy`,
-      languages: { en: "/en/privacy", ko: "/ko/privacy" },
+      canonical: locale === "en" ? "/privacy" : `/${locale}/privacy`,
+      languages: { en: "/privacy", ko: "/ko/privacy" },
     },
   };
 }

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -12,8 +12,8 @@ export async function generateMetadata({
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `/${locale}/terms`,
-      languages: { en: "/en/terms", ko: "/ko/terms" },
+      canonical: locale === "en" ? "/terms" : `/${locale}/terms`,
+      languages: { en: "/terms", ko: "/ko/terms" },
     },
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,10 +2,13 @@ import { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: "/_next/static/",
+      },
+    ],
     sitemap: "https://json-animation-viewer.com/sitemap.xml",
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -95,13 +95,21 @@ const pages: SitemapEntry[] = [
 export default function sitemap(): MetadataRoute.Sitemap {
   return pages.flatMap((page) =>
     locales.map((locale) => ({
-      url: `${BASE_URL}/${locale}${page.path}`,
+      url:
+        locale === "en"
+          ? `${BASE_URL}${page.path || "/"}`
+          : `${BASE_URL}/${locale}${page.path}`,
       lastModified: new Date(page.lastModified),
       changeFrequency: page.changeFrequency,
       priority: page.priority,
       alternates: {
         languages: Object.fromEntries(
-          locales.map((l) => [l, `${BASE_URL}/${l}${page.path}`])
+          locales.map((l) => [
+            l,
+            l === "en"
+              ? `${BASE_URL}${page.path || "/"}`
+              : `${BASE_URL}/${l}${page.path}`,
+          ])
         ),
       },
     }))

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -3,4 +3,5 @@ import { defineRouting } from "next-intl/routing";
 export const routing = defineRouting({
   locales: ["en", "ko"],
   defaultLocale: "en",
+  localePrefix: "as-needed",
 });


### PR DESCRIPTION
## 📌 Summary

Google Search Console에서 보고된 5가지 색인 문제를 해결하기 위해, `/en/*` canonical URL 충돌을 완전히 제거하고 올바른 SEO 구조로 수정합니다.

## 📋 Changes

- `./src/i18n/routing.ts`: `localePrefix: "as-needed"` 추가 — 영어 페이지에서 `/en` prefix 제거, `/`→`/en` 리디렉션 해소
- `./src/app/robots.ts`: `disallow: "/_next/static/"` 추가 — 폰트(.woff2) 등 정적 자산 크롤링 차단
- `./src/app/sitemap.ts`: 영어 URL에서 `/en` prefix 제거 (`/en/blog` → `/blog`)
- `./src/app/[locale]/layout.tsx`: 루트 canonical을 `/en` → `/`, `alternate languages` 수정
- `./src/app/[locale]/about/page.tsx`: canonical `/en/about` → `/about`
- `./src/app/[locale]/blog/page.tsx`: canonical `/en/blog` → `/blog`
- `./src/app/[locale]/faq/page.tsx`: canonical `/en/faq` → `/faq`
- `./src/app/[locale]/guide/page.tsx`: canonical `/en/guide` → `/guide`
- `./src/app/[locale]/privacy/page.tsx`: canonical `/en/privacy` → `/privacy`
- `./src/app/[locale]/terms/page.tsx`: canonical `/en/terms` → `/terms`
- `./src/app/[locale]/blog/what-is-lottie/page.tsx`: canonical 수정
- `./src/app/[locale]/blog/json-animation-tutorial/page.tsx`: canonical 수정
- `./src/app/[locale]/blog/lottie-vs-gif/page.tsx`: canonical 수정
- `./src/app/[locale]/blog/best-lottie-resources/page.tsx`: canonical 수정
- `./src/app/[locale]/blog/how-to-create-lottie-animation/page.tsx`: canonical 수정

## 🧠 Context & Background

**근본 원인**: `next-intl`의 `localePrefix` 기본값이 `"always"`로 설정되어 있어, 미들웨어가 루트 `/` 접근 시 `/en`으로 리디렉션을 발생시켰습니다. Google은 리디렉션 소스인 `/`를 canonical로 판단했고, 사이트는 `/en`을 canonical이라고 주장했기 때문에 충돌이 발생했습니다.

**해결 방법**: `localePrefix: "as-needed"` 전환으로:
- 영어 URL: `/en/*` → `/*` (prefix 없음)
- 한국어 URL: `/ko/*` 유지
- 루트 `/` 리디렉션 완전 제거

**해소되는 Search Console 문제 5가지**:
1. 중복 페이지, Google에서 사용자와 다른 표준을 선택함 (1건)
2. 발견됨 - 현재 색인이 생성되지 않음 (21건)
3. 크롤링됨 - 현재 색인이 생성되지 않음 (2건, 폰트 파일)
4. 리디렉션이 포함된 페이지 (3건)
5. 적절한 표준 태그가 포함된 대체 페이지 (2건)

## ✅ How to Test

1. `npm run build` 실행 → 빌드 성공 확인 (이미 로컬에서 통과 ✅)
2. `npm run dev` 후 `http://localhost:3000` 접속 → `/en` prefix 없이 영어 페이지 정상 렌더링 확인
3. `http://localhost:3000/sitemap.xml` 확인 → 영어 URL에 `/en` prefix가 없는지 확인
4. `http://localhost:3000/robots.txt` 확인 → `Disallow: /_next/static/` 포함 여부 확인
5. 각 페이지 소스에서 `<link rel="canonical">` 태그 확인 → 영어 페이지는 `/en` 없는 URL이어야 함
6. Vercel 배포 후 Google Search Console에서 URL 검사 도구로 canonical 재확인

## 🔗 Related Issues

- Google Search Console 색인 문제 보고 (스크린샷 5장)

## 🙌 Additional Notes

- 빌드 결과: ✅ 31개 페이지 정상 생성, TypeScript/ESLint 에러 없음
- 한국어 라우팅(`/ko/*`)은 변경 없음
- `"as-needed"` 모드는 기본 locale(영어) 사용자 경험에도 더 자연스러운 URL 구조를 제공