### PR TITLE
feature/fix-www-canonical-redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,12 @@ const nextConfig: NextConfig = {
         destination: "https://json-animation-viewer.com/:path*",
         permanent: true,
       },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.json-animation-viewer.com" }],
+        destination: "https://json-animation-viewer.com/:path*",
+        permanent: true,
+      },
     ];
   },
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,5 +4,5 @@ import { routing } from "./i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/", "/(ko|en)/:path*"],
+  matcher: ["/", "/(ko|en)", "/(ko|en)/:path*"],
 };


### PR DESCRIPTION
## 📌 Summary

Google Search Console에서 발생한 색인 실패 문제(적절한 표준 태그가 포함된 대체 페이지)를 수정합니다.

## 📋 Changes

- \`./next.config.ts\`: www.json-animation-viewer.com → json-animation-viewer.com 301 영구 리다이렉트 추가
- \`./src/middleware.ts\`: middleware matcher에 \`/(ko|en)\` 패턴 추가 (/en 단독 접근 처리)

## 🧠 Context & Background

Google Search Console에서 두 URL이 색인 실패:
- \`https://www.json-animation-viewer.com/ko/blog\`
- \`https://www.json-animation-viewer.com/en\`

**원인 1 (www canonical 불일치)**
\`metadataBase\`가 \`https://json-animation-viewer.com\` (non-www)이지만 Google이 www 버전을 크롤링함.
canonical 태그가 non-www를 가리키므로 Google이 www 버전을 "대체 페이지"로 처리해 색인하지 않음.
→ www → non-www 301 리다이렉트로 해결

**원인 2 (middleware /en 미처리)**
기존 matcher \`/(ko|en)/:path*\`는 \`/en/subpath\` 형태만 매칭하고 \`/en\` 단독은 매칭 안 함.
→ Google이 \`/en\`을 크롤링하면 미들웨어 리다이렉트 없이 페이지가 렌더되어 canonical \`/\`의 대체 페이지로 처리됨.
→ matcher에 \`/(ko|en)\` 추가로 해결

## ✅ How to Test

1. `www.json-animation-viewer.com` 접속 시 `json-animation-viewer.com`으로 301 리다이렉트 확인
2. `json-animation-viewer.com/en` 접속 시 `json-animation-viewer.com/`으로 리다이렉트 확인
3. Google Search Console에서 해당 URL 재검사 후 색인 정상 처리 확인

## 🔗 Related Issues

- Google Search Console 색인 실패: "적절한 표준 태그가 포함된 대체 페이지"