### PR TITLE
dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,12 @@ const nextConfig: NextConfig = {
         destination: "https://json-animation-viewer.com/:path*",
         permanent: true,
       },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.json-animation-viewer.com" }],
+        destination: "https://json-animation-viewer.com/:path*",
+        permanent: true,
+      },
     ];
   },
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,5 +4,5 @@ import { routing } from "./i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/", "/(ko|en)/:path*"],
+  matcher: ["/", "/(ko|en)", "/(ko|en)/:path*"],
 };


### PR DESCRIPTION
## 📌 Summary

Google Search Console 색인 실패 문제를 수정한 변경사항을 main에 반영합니다.

## 📋 Changes

- \`./next.config.ts\`: www.json-animation-viewer.com → json-animation-viewer.com 301 영구 리다이렉트 추가
- \`./src/middleware.ts\`: middleware matcher에 \`/(ko|en)\` 패턴 추가 (/en 단독 접근 처리)

## 🧠 Context & Background

Google Search Console에서 두 URL이 색인 실패("적절한 표준 태그가 포함된 대체 페이지"):
- \`https://www.json-animation-viewer.com/ko/blog\`
- \`https://www.json-animation-viewer.com/en\`

canonical 도메인(non-www)과 실제 크롤링 URL(www) 불일치 및 /en 미들웨어 미처리 문제 수정.
자세한 내용은 PR #18 참고.

## ✅ How to Test

1. \`www.json-animation-viewer.com\` 접속 → \`json-animation-viewer.com\`으로 301 리다이렉트 확인
2. \`json-animation-viewer.com/en\` 접속 → \`json-animation-viewer.com/\`으로 리다이렉트 확인
3. Google Search Console 재검사 후 색인 정상 처리 확인

## 🔗 Related Issues

- PR #18: feature/fix-www-canonical-redirect → dev