### PR TITLE
fix: add Google Search Console verification meta tag

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -96,6 +96,9 @@ export async function generateMetadata({
       images: ["/og-image.png"],
     },
     category: "technology",
+    verification: {
+      google: "google720166e0719705ae",
+    },
   };
 }
 


### PR DESCRIPTION
## 변경 사항

### 문제
`[locale]/layout.tsx`의 generateMetadata에 Google Search Console verification 코드가 누락되어 있었음.
`public/google720166e0719705ae.html` 파일은 있지만 메타태그 방식 verification이 설정되지 않아 Search Console 색인 문제에 영향.

### 수정
- `[locale]/layout.tsx` generateMetadata에 verification.google 추가
  ```
  verification: {
    google: "google720166e0719705ae",
  }
  ```

### 기대 효과
- Google Search Console에서 올바른 소유권 인증
- 색인 생성 요청 가속화 기대

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Google site verification to enhance search engine recognition and site credibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->