### PR TITLE
feature/JSO-1-phase-a-analyzer-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^4.1.4",
         "critters": "^0.0.25",
         "eslint": "^9",
         "eslint-config-next": "^15.5.12",
         "tailwindcss": "^4",
         "typescript": "5.9.3",
+        "vitest": "^4.1.4",
         "webpack-bundle-analyzer": "^4.10.2"
       }
     },
@@ -41,6 +43,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -50,10 +112,33 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -769,6 +854,53 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.12",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
@@ -958,6 +1090,16 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -1289,6 +1431,270 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1305,6 +1711,13 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
@@ -1713,6 +2126,35 @@
         "tailwindcss": "4.0.12"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2040,6 +2482,123 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2268,11 +2827,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2426,6 +3014,16 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2479,6 +3077,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/critters": {
       "version": "0.0.25",
@@ -2907,6 +3512,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3372,6 +3984,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3379,6 +4001,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4267,6 +4899,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4397,10 +5068,11 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
-      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -4412,26 +5084,49 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.2",
-        "lightningcss-darwin-x64": "1.29.2",
-        "lightningcss-freebsd-x64": "1.29.2",
-        "lightningcss-linux-arm-gnueabihf": "1.29.2",
-        "lightningcss-linux-arm64-gnu": "1.29.2",
-        "lightningcss-linux-arm64-musl": "1.29.2",
-        "lightningcss-linux-x64-gnu": "1.29.2",
-        "lightningcss-linux-x64-musl": "1.29.2",
-        "lightningcss-win32-arm64-msvc": "1.29.2",
-        "lightningcss-win32-x64-msvc": "1.29.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
-      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -4445,13 +5140,14 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
-      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -4465,13 +5161,14 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
-      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -4485,13 +5182,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
-      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4505,13 +5203,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
-      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4525,13 +5224,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
-      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4545,13 +5245,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
-      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4565,13 +5266,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
-      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4585,13 +5287,14 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
-      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -4605,13 +5308,14 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
-      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -4661,6 +5365,44 @@
       "version": "5.12.2",
       "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.12.2.tgz",
       "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4732,15 +5474,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
-      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5061,6 +5804,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -5170,6 +5924,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5236,9 +5997,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -5254,8 +6015,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5433,6 +6195,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/run-parallel": {
@@ -5713,6 +6509,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -5740,6 +6543,20 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
       "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -5930,6 +6747,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5976,6 +6810,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6184,6 +7028,229 @@
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
@@ -6308,6 +7375,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "playwright test",
-    "test:headed": "playwright test --headed"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "lottie-web": "^5.12.2",
@@ -24,11 +26,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.4",
     "critters": "^0.0.25",
     "eslint": "^9",
     "eslint-config-next": "^15.5.12",
     "tailwindcss": "^4",
     "typescript": "5.9.3",
+    "vitest": "^4.1.4",
     "webpack-bundle-analyzer": "^4.10.2"
   }
 }

--- a/src/lib/lottie-analyzer/__fixtures__.ts
+++ b/src/lib/lottie-analyzer/__fixtures__.ts
@@ -1,0 +1,150 @@
+import type { LottieJson } from "./types";
+
+export const minimalLottie: LottieJson = {
+  v: "5.7.0",
+  fr: 30,
+  ip: 0,
+  op: 60,
+  w: 512,
+  h: 512,
+  nm: "minimal",
+  ddd: 0,
+  assets: [],
+  layers: [
+    {
+      ty: 4,
+      nm: "Shape 1",
+      ind: 1,
+      ip: 0,
+      op: 60,
+      shapes: [
+        {
+          ty: "sh",
+          ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[0, 0]] }] },
+        },
+      ],
+    },
+  ],
+  meta: { g: "After Effects 22.0" },
+};
+
+export const complexLottie: LottieJson = {
+  v: "5.10.0",
+  fr: 60,
+  ip: 0,
+  op: 180,
+  w: 1920,
+  h: 1080,
+  nm: "complex",
+  ddd: 1,
+  assets: [
+    {
+      id: "image_0",
+      w: 5000,
+      h: 5000,
+      p: "data:image/png;base64,iVBORw0K",
+      e: 1,
+    },
+    {
+      id: "image_1",
+      w: 256,
+      h: 256,
+      p: "image_1.png",
+      e: 0,
+    },
+    {
+      id: "comp_0",
+      layers: [
+        {
+          ty: 4,
+          nm: "Inner Shape",
+          ind: 1,
+          ip: 0,
+          op: 180,
+          shapes: [
+            {
+              ty: "sh",
+              ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[1, 1]] }] },
+            },
+          ],
+          ks: {
+            p: {
+              k: [
+                { t: 0, s: [0] },
+                { t: 30, s: [100] },
+              ],
+              x: "time*100",
+            },
+          },
+        },
+      ],
+    },
+  ],
+  layers: [
+    {
+      ty: 2,
+      nm: "Image Layer",
+      ind: 1,
+      ip: 0,
+      op: 180,
+      refId: "image_0",
+      ddd: 1,
+    },
+    {
+      ty: 4,
+      nm: "Shape Layer 1",
+      ind: 2,
+      ip: 0,
+      op: 180,
+      hd: true,
+      shapes: [
+        {
+          ty: "sh",
+          ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[5, 5]] }] },
+        },
+        {
+          ty: "sh",
+          ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[5, 5]] }] },
+        },
+        { ty: "mm" },
+        { ty: "gs" },
+        { ty: "tm" },
+      ],
+      ef: [{ ty: 1 }, { ty: 2 }],
+      masksProperties: [{ mode: "a" }, { mode: "s" }],
+    },
+    {
+      ty: 5,
+      nm: "Text Layer",
+      ind: 3,
+      ip: 0,
+      op: 180,
+      t: {
+        d: { k: [{ t: 0, s: { t: "hello" } }] },
+        m: { g: 2 },
+        a: [{ foo: 1 }],
+      },
+      tt: 1,
+    },
+  ],
+  markers: [{ tm: 0, cm: "start" }],
+  meta: { g: "After Effects 23.0" },
+};
+
+export const lottieWithUnnamedLayers: LottieJson = {
+  v: "5.7.0",
+  fr: 30,
+  ip: 0,
+  op: 60,
+  w: 512,
+  h: 512,
+  ddd: 0,
+  assets: [],
+  layers: Array.from({ length: 12 }).map((_, i) => ({
+    ty: 4 as const,
+    nm: `Shape Layer ${i + 1}`,
+    ind: i + 1,
+    ip: 0,
+    op: 60,
+  })),
+};

--- a/src/lib/lottie-analyzer/compatibility.test.ts
+++ b/src/lib/lottie-analyzer/compatibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildCompatibility } from "./compatibility";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { extractMetadata } from "./metadata";
+import { scanLottie } from "./scan";
+
+describe("buildCompatibility", () => {
+  function run(data: typeof minimalLottie) {
+    const metadata = extractMetadata(data);
+    const scan = scanLottie(data);
+    return buildCompatibility({ metadata, scan });
+  }
+
+  it("lists the full feature matrix", () => {
+    const result = run(minimalLottie);
+    expect(result.features.map((f) => f.feature)).toEqual([
+      "Expressions",
+      "Merge Paths",
+      "3D Layers",
+      "Mattes",
+      "Gradient Strokes",
+      "Per-character Text",
+      "Trim Path (individually)",
+    ]);
+  });
+
+  it("marks features as detected when present in file", () => {
+    const result = run(complexLottie);
+    const expr = result.features.find((f) => f.feature === "Expressions");
+    const threeD = result.features.find((f) => f.feature === "3D Layers");
+    expect(expr?.detectedInFile).toBe(true);
+    expect(threeD?.detectedInFile).toBe(true);
+  });
+
+  it("computes a summary per platform reflecting worst detected feature", () => {
+    const result = run(complexLottie);
+    expect(result.summary.ios.overall).toBe("unsupported");
+    expect(result.summary.android.overall).toBe("unsupported");
+    expect(result.summary.web.overall === "partial" || result.summary.web.overall === "supported").toBe(true);
+  });
+
+  it("returns 'supported' for every platform on a clean minimal file", () => {
+    const result = run(minimalLottie);
+    expect(result.summary.web.overall).toBe("supported");
+    expect(result.summary.ios.overall).toBe("supported");
+    expect(result.summary.android.overall).toBe("supported");
+  });
+});

--- a/src/lib/lottie-analyzer/compatibility.ts
+++ b/src/lib/lottie-analyzer/compatibility.ts
@@ -1,0 +1,143 @@
+import { DeepScanResult } from "./scan";
+import {
+  LottieMetadata,
+  PlatformCompatibility,
+  PlatformFeatureSupport,
+  PlatformKey,
+  PlatformSupportLevel,
+} from "./types";
+
+interface FeatureDef {
+  feature: string;
+  web: PlatformSupportLevel;
+  ios: PlatformSupportLevel;
+  android: PlatformSupportLevel;
+}
+
+const FEATURE_MATRIX: FeatureDef[] = [
+  {
+    feature: "Expressions",
+    web: "partial",
+    ios: "unsupported",
+    android: "unsupported",
+  },
+  {
+    feature: "Merge Paths",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "3D Layers",
+    web: "partial",
+    ios: "unsupported",
+    android: "unsupported",
+  },
+  {
+    feature: "Mattes",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "Gradient Strokes",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "Per-character Text",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "Trim Path (individually)",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+];
+
+function severityRank(level: PlatformSupportLevel): number {
+  if (level === "unsupported") return 2;
+  if (level === "partial") return 1;
+  return 0;
+}
+
+function worstLevel(a: PlatformSupportLevel, b: PlatformSupportLevel): PlatformSupportLevel {
+  return severityRank(a) >= severityRank(b) ? a : b;
+}
+
+interface BuildCompatibilityInput {
+  metadata: LottieMetadata;
+  scan: DeepScanResult;
+}
+
+export function buildCompatibility(
+  input: BuildCompatibilityInput,
+): PlatformCompatibility {
+  const { metadata, scan } = input;
+
+  const detectionMap: Record<string, { detected: boolean; layers: number[] }> = {
+    Expressions: {
+      detected: scan.totalExpressions > 0,
+      layers: Array.from(scan.expressionLayerIndexes),
+    },
+    "Merge Paths": {
+      detected: scan.hasMergePathsLayerIndexes.size > 0,
+      layers: Array.from(scan.hasMergePathsLayerIndexes),
+    },
+    "3D Layers": {
+      detected: metadata.is3D,
+      layers: [],
+    },
+    Mattes: {
+      detected: scan.hasMatteLayerIndexes.size > 0,
+      layers: Array.from(scan.hasMatteLayerIndexes),
+    },
+    "Gradient Strokes": {
+      detected: scan.hasGradientStrokeLayerIndexes.size > 0,
+      layers: Array.from(scan.hasGradientStrokeLayerIndexes),
+    },
+    "Per-character Text": {
+      detected: scan.hasPerCharTextLayerIndexes.size > 0,
+      layers: Array.from(scan.hasPerCharTextLayerIndexes),
+    },
+    "Trim Path (individually)": {
+      detected: scan.hasTrimPathLayerIndexes.size > 0,
+      layers: Array.from(scan.hasTrimPathLayerIndexes),
+    },
+  };
+
+  const features: PlatformFeatureSupport[] = FEATURE_MATRIX.map((def) => {
+    const detection = detectionMap[def.feature];
+    return {
+      feature: def.feature,
+      web: def.web,
+      ios: def.ios,
+      android: def.android,
+      detectedInFile: detection?.detected ?? false,
+      relatedLayerIndexes: detection?.layers ?? [],
+    };
+  });
+
+  const initial: PlatformCompatibility["summary"] = {
+    web: { overall: "supported", unsupportedCount: 0, partialCount: 0 },
+    ios: { overall: "supported", unsupportedCount: 0, partialCount: 0 },
+    android: { overall: "supported", unsupportedCount: 0, partialCount: 0 },
+  };
+
+  const platforms: PlatformKey[] = ["web", "ios", "android"];
+  for (const feature of features) {
+    if (!feature.detectedInFile) continue;
+    for (const platform of platforms) {
+      const level = feature[platform];
+      initial[platform].overall = worstLevel(initial[platform].overall, level);
+      if (level === "unsupported") initial[platform].unsupportedCount += 1;
+      if (level === "partial") initial[platform].partialCount += 1;
+    }
+  }
+
+  return { features, summary: initial };
+}

--- a/src/lib/lottie-analyzer/index.test.ts
+++ b/src/lib/lottie-analyzer/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { analyzeLottie } from "./index";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+
+describe("analyzeLottie", () => {
+  it("returns a combined analysis bundle", () => {
+    const result = analyzeLottie(minimalLottie, { fileSizeBytes: 1024 });
+    expect(result.metadata.fileSizeBytes).toBe(1024);
+    expect(result.layers.layers.length).toBe(1);
+    expect(result.performance.grade).toBe("A");
+    expect(Array.isArray(result.suggestions)).toBe(true);
+    expect(result.compatibility.features.length).toBeGreaterThan(0);
+  });
+
+  it("produces meaningful output on a complex file", () => {
+    const result = analyzeLottie(complexLottie);
+    expect(result.suggestions.length).toBeGreaterThan(0);
+    expect(result.performance.score).toBeLessThan(90);
+    expect(result.compatibility.summary.ios.overall).toBe("unsupported");
+  });
+});

--- a/src/lib/lottie-analyzer/index.ts
+++ b/src/lib/lottie-analyzer/index.ts
@@ -1,0 +1,79 @@
+import { buildCompatibility } from "./compatibility";
+import { analyzeLayers } from "./layers";
+import { extractMetadata } from "./metadata";
+import { buildOptimizationSuggestions } from "./optimization";
+import { computePerformanceScore } from "./performance";
+import { scanLottie } from "./scan";
+import type { LottieAnalysisResult, LottieJson } from "./types";
+
+export interface AnalyzeLottieOptions {
+  fileSizeBytes?: number | null;
+  targetDimensions?: { width: number | null; height: number | null };
+}
+
+export function analyzeLottie(
+  data: LottieJson,
+  options: AnalyzeLottieOptions = {},
+): LottieAnalysisResult {
+  const metadata = extractMetadata(data, {
+    fileSizeBytes: options.fileSizeBytes ?? null,
+  });
+  const layerAnalysis = analyzeLayers(data);
+  const scan = scanLottie(data);
+
+  const totalEffects = layerAnalysis.layers.reduce(
+    (sum, l) => sum + l.effectCount,
+    0,
+  );
+  const totalMasks = layerAnalysis.layers.reduce(
+    (sum, l) => sum + l.maskCount,
+    0,
+  );
+
+  const performance = computePerformanceScore({
+    metadata,
+    scan,
+    totalEffects,
+    totalMasks,
+  });
+
+  const suggestions = buildOptimizationSuggestions({
+    metadata,
+    layers: layerAnalysis.layers,
+    scan,
+    targetDimensions: options.targetDimensions,
+  });
+
+  const compatibility = buildCompatibility({ metadata, scan });
+
+  return {
+    metadata,
+    layers: layerAnalysis,
+    performance,
+    suggestions,
+    compatibility,
+  };
+}
+
+export * from "./types";
+export {
+  extractMetadata,
+  formatDuration,
+  formatFileSize,
+} from "./metadata";
+export { analyzeLayers, getBlendModeName, BLEND_MODE_NAMES } from "./layers";
+export { scanLottie } from "./scan";
+export type { DeepScanResult } from "./scan";
+export {
+  computePerformanceScore,
+  gradeFromScore,
+  scoreLayerCount,
+  scoreExpressions,
+  scoreEffects,
+  scoreMasks,
+  score3D,
+  scoreEmbeddedImages,
+  scoreFrameRate,
+} from "./performance";
+export { buildOptimizationSuggestions } from "./optimization";
+export { buildCompatibility } from "./compatibility";

--- a/src/lib/lottie-analyzer/layers.test.ts
+++ b/src/lib/lottie-analyzer/layers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { analyzeLayers, getBlendModeName } from "./layers";
+
+describe("analyzeLayers", () => {
+  it("produces an analyzed entry for each layer", () => {
+    const result = analyzeLayers(minimalLottie);
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].typeName).toBe("Shape");
+    expect(result.layers[0].isHidden).toBe(false);
+  });
+
+  it("captures effect and mask counts", () => {
+    const result = analyzeLayers(complexLottie);
+    const shape = result.layers.find((l) => l.typeName === "Shape");
+    expect(shape?.effectCount).toBe(2);
+    expect(shape?.maskCount).toBe(2);
+    expect(shape?.isHidden).toBe(true);
+  });
+
+  it("flags 3D layers", () => {
+    const result = analyzeLayers(complexLottie);
+    const image = result.layers.find((l) => l.typeName === "Image");
+    expect(image?.is3D).toBe(true);
+  });
+
+  it("builds a parent-child tree", () => {
+    const data = {
+      ...minimalLottie,
+      layers: [
+        { ty: 3 as const, nm: "Parent", ind: 1, ip: 0, op: 60 },
+        { ty: 4 as const, nm: "Child", ind: 2, ip: 0, op: 60, parent: 1 },
+      ],
+    };
+    const result = analyzeLayers(data);
+    expect(result.tree).toHaveLength(1);
+    expect(result.tree[0].children).toHaveLength(1);
+    expect(result.tree[0].children[0].name).toBe("Child");
+  });
+});
+
+describe("getBlendModeName", () => {
+  it("maps known blend mode codes to names", () => {
+    expect(getBlendModeName(0)).toBe("Normal");
+    expect(getBlendModeName(1)).toBe("Multiply");
+    expect(getBlendModeName(99)).toBe("Mode 99");
+  });
+});

--- a/src/lib/lottie-analyzer/layers.ts
+++ b/src/lib/lottie-analyzer/layers.ts
@@ -1,0 +1,86 @@
+import {
+  AnalyzedLayer,
+  LAYER_TYPE_NAMES,
+  LayerAnalysisResult,
+  LayerTreeNode,
+  LayerTypeCode,
+  LottieJson,
+  LottieLayer,
+} from "./types";
+
+function countMasks(layer: LottieLayer): number {
+  if (Array.isArray(layer.masksProperties)) return layer.masksProperties.length;
+  return 0;
+}
+
+function countEffects(layer: LottieLayer): number {
+  if (Array.isArray(layer.ef)) return layer.ef.length;
+  return 0;
+}
+
+export function analyzeLayers(data: LottieJson): LayerAnalysisResult {
+  const rawLayers: LottieLayer[] = Array.isArray(data.layers) ? data.layers : [];
+
+  const layers: AnalyzedLayer[] = rawLayers.map((layer, idx) => {
+    const typeCode = layer.ty as LayerTypeCode;
+    const typeName = LAYER_TYPE_NAMES[typeCode] ?? `Unknown(${String(typeCode)})`;
+    const name =
+      typeof layer.nm === "string" && layer.nm.length > 0
+        ? layer.nm
+        : `Layer ${idx + 1}`;
+    return {
+      index: typeof layer.ind === "number" ? layer.ind : idx,
+      name,
+      typeCode,
+      typeName,
+      startFrame: typeof layer.ip === "number" ? layer.ip : 0,
+      endFrame: typeof layer.op === "number" ? layer.op : 0,
+      blendMode: typeof layer.bm === "number" ? layer.bm : 0,
+      is3D: layer.ddd === 1,
+      effectCount: countEffects(layer),
+      maskCount: countMasks(layer),
+      parent: typeof layer.parent === "number" ? layer.parent : null,
+      isHidden: layer.hd === true,
+    };
+  });
+
+  const byIndex = new Map<number, LayerTreeNode>();
+  const tree: LayerTreeNode[] = [];
+
+  for (const analyzed of layers) {
+    byIndex.set(analyzed.index, { ...analyzed, children: [] });
+  }
+
+  for (const node of byIndex.values()) {
+    if (node.parent !== null && byIndex.has(node.parent)) {
+      byIndex.get(node.parent)!.children.push(node);
+    } else {
+      tree.push(node);
+    }
+  }
+
+  return { layers, tree };
+}
+
+export const BLEND_MODE_NAMES: Record<number, string> = {
+  0: "Normal",
+  1: "Multiply",
+  2: "Screen",
+  3: "Overlay",
+  4: "Darken",
+  5: "Lighten",
+  6: "Color Dodge",
+  7: "Color Burn",
+  8: "Hard Light",
+  9: "Soft Light",
+  10: "Difference",
+  11: "Exclusion",
+  12: "Hue",
+  13: "Saturation",
+  14: "Color",
+  15: "Luminosity",
+};
+
+export function getBlendModeName(code: number): string {
+  return BLEND_MODE_NAMES[code] ?? `Mode ${code}`;
+}

--- a/src/lib/lottie-analyzer/metadata.test.ts
+++ b/src/lib/lottie-analyzer/metadata.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { extractMetadata, formatDuration, formatFileSize } from "./metadata";
+
+describe("extractMetadata", () => {
+  it("extracts version, generator, dimensions, framerate, duration", () => {
+    const meta = extractMetadata(minimalLottie);
+    expect(meta.version).toBe("5.7.0");
+    expect(meta.generator).toBe("After Effects 22.0");
+    expect(meta.width).toBe(512);
+    expect(meta.height).toBe(512);
+    expect(meta.frameRate).toBe(30);
+    expect(meta.totalFrames).toBe(60);
+    expect(meta.durationSeconds).toBeCloseTo(2, 5);
+  });
+
+  it("counts layers by type and counts assets", () => {
+    const meta = extractMetadata(complexLottie);
+    expect(meta.layerCount).toBe(3);
+    expect(meta.layerCountsByType.Shape).toBe(1);
+    expect(meta.layerCountsByType.Image).toBe(1);
+    expect(meta.layerCountsByType.Text).toBe(1);
+    expect(meta.assetCount).toBe(3);
+    expect(meta.imageAssetCount).toBe(2);
+    expect(meta.precompAssetCount).toBe(1);
+    expect(meta.embeddedImageCount).toBe(1);
+    expect(meta.markerCount).toBe(1);
+  });
+
+  it("detects 3D from ddd flag at root or layer", () => {
+    expect(extractMetadata(complexLottie).is3D).toBe(true);
+    expect(extractMetadata(minimalLottie).is3D).toBe(false);
+  });
+
+  it("returns null fallbacks for missing fields", () => {
+    const meta = extractMetadata({});
+    expect(meta.version).toBeNull();
+    expect(meta.width).toBeNull();
+    expect(meta.height).toBeNull();
+    expect(meta.frameRate).toBeNull();
+    expect(meta.totalFrames).toBeNull();
+    expect(meta.durationSeconds).toBeNull();
+    expect(meta.layerCount).toBe(0);
+    expect(meta.assetCount).toBe(0);
+    expect(meta.is3D).toBe(false);
+  });
+
+  it("accepts fileSizeBytes option", () => {
+    const meta = extractMetadata(minimalLottie, { fileSizeBytes: 2048 });
+    expect(meta.fileSizeBytes).toBe(2048);
+  });
+});
+
+describe("formatters", () => {
+  it("formats duration", () => {
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(2.345)).toBe("2.35s");
+    expect(formatDuration(30)).toBe("30.0s");
+  });
+
+  it("formats file size", () => {
+    expect(formatFileSize(null)).toBe("—");
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(2048)).toBe("2.0 KB");
+    expect(formatFileSize(5 * 1024 * 1024)).toBe("5.00 MB");
+  });
+});

--- a/src/lib/lottie-analyzer/metadata.ts
+++ b/src/lib/lottie-analyzer/metadata.ts
@@ -1,0 +1,132 @@
+import {
+  LAYER_TYPE_NAMES,
+  LayerTypeCode,
+  LottieJson,
+  LottieLayer,
+  LottieMetadata,
+} from "./types";
+
+const DEFAULT_COUNTS: Record<string, number> = Object.values(LAYER_TYPE_NAMES).reduce(
+  (acc, name) => {
+    acc[name] = 0;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+
+function collectAllLayers(data: LottieJson): LottieLayer[] {
+  const result: LottieLayer[] = [];
+  const rootLayers = Array.isArray(data.layers) ? data.layers : [];
+  for (const layer of rootLayers) {
+    result.push(layer);
+  }
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  for (const asset of assets) {
+    if (Array.isArray(asset.layers)) {
+      for (const layer of asset.layers) {
+        result.push(layer);
+      }
+    }
+  }
+  return result;
+}
+
+function countEmbeddedImages(data: LottieJson): number {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  let count = 0;
+  for (const asset of assets) {
+    const isImage = typeof asset.p === "string" && asset.p.length > 0;
+    if (!isImage) continue;
+    const isEmbedded =
+      asset.e === 1 ||
+      (typeof asset.p === "string" && asset.p.startsWith("data:"));
+    if (isEmbedded) count += 1;
+  }
+  return count;
+}
+
+function countImageAssets(data: LottieJson): number {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  return assets.filter((a) => typeof a.p === "string" && a.p.length > 0).length;
+}
+
+function countPrecompAssets(data: LottieJson): number {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  return assets.filter((a) => Array.isArray(a.layers)).length;
+}
+
+function detect3D(data: LottieJson): boolean {
+  if (data.ddd === 1) return true;
+  const layers = collectAllLayers(data);
+  return layers.some((l) => l.ddd === 1);
+}
+
+function countLayersByType(layers: LottieLayer[]): Record<string, number> {
+  const counts: Record<string, number> = { ...DEFAULT_COUNTS };
+  for (const layer of layers) {
+    const typeCode = layer.ty as LayerTypeCode;
+    const typeName = LAYER_TYPE_NAMES[typeCode];
+    if (typeName) {
+      counts[typeName] += 1;
+    }
+  }
+  return counts;
+}
+
+export interface ExtractMetadataOptions {
+  fileSizeBytes?: number | null;
+}
+
+export function extractMetadata(
+  data: LottieJson,
+  options: ExtractMetadataOptions = {},
+): LottieMetadata {
+  const rootLayers = Array.isArray(data.layers) ? data.layers : [];
+  const ip = typeof data.ip === "number" ? data.ip : null;
+  const op = typeof data.op === "number" ? data.op : null;
+  const fr = typeof data.fr === "number" ? data.fr : null;
+
+  let totalFrames: number | null = null;
+  let duration: number | null = null;
+  if (ip !== null && op !== null) {
+    totalFrames = Math.max(0, op - ip);
+    if (fr && fr > 0) {
+      duration = totalFrames / fr;
+    }
+  }
+
+  return {
+    version: typeof data.v === "string" ? data.v : null,
+    generator: typeof data.meta?.g === "string" ? data.meta.g : null,
+    width: typeof data.w === "number" ? data.w : null,
+    height: typeof data.h === "number" ? data.h : null,
+    frameRate: fr,
+    inPoint: ip,
+    outPoint: op,
+    totalFrames,
+    durationSeconds: duration,
+    layerCount: rootLayers.length,
+    layerCountsByType: countLayersByType(rootLayers),
+    assetCount: Array.isArray(data.assets) ? data.assets.length : 0,
+    imageAssetCount: countImageAssets(data),
+    precompAssetCount: countPrecompAssets(data),
+    embeddedImageCount: countEmbeddedImages(data),
+    markerCount: Array.isArray(data.markers) ? data.markers.length : 0,
+    fileSizeBytes:
+      typeof options.fileSizeBytes === "number" ? options.fileSizeBytes : null,
+    is3D: detect3D(data),
+  };
+}
+
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds)) return "—";
+  if (seconds < 10) return `${seconds.toFixed(2)}s`;
+  return `${seconds.toFixed(1)}s`;
+}
+
+export function formatFileSize(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes)) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/src/lib/lottie-analyzer/optimization.test.ts
+++ b/src/lib/lottie-analyzer/optimization.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  complexLottie,
+  lottieWithUnnamedLayers,
+  minimalLottie,
+} from "./__fixtures__";
+import { analyzeLayers } from "./layers";
+import { extractMetadata } from "./metadata";
+import { buildOptimizationSuggestions } from "./optimization";
+import { scanLottie } from "./scan";
+import type { SuggestionCode } from "./types";
+
+function codes(data: typeof minimalLottie): SuggestionCode[] {
+  const metadata = extractMetadata(data);
+  const layers = analyzeLayers(data);
+  const scan = scanLottie(data);
+  return buildOptimizationSuggestions({
+    metadata,
+    layers: layers.layers,
+    scan,
+  }).map((s) => s.code);
+}
+
+describe("buildOptimizationSuggestions", () => {
+  it("detects embedded images, expressions, hidden layers, duplicates, matte/gradient/trim assets on a complex file", () => {
+    const result = codes(complexLottie);
+    expect(result).toContain("EMBEDDED_IMAGES");
+    expect(result).toContain("EXPRESSIONS");
+    expect(result).toContain("HIDDEN_LAYERS");
+    expect(result).toContain("DUPLICATE_SHAPE_PATHS");
+    expect(result).toContain("LARGE_IMAGE_RESIZE");
+  });
+
+  it("flags unnamed default-name layers", () => {
+    const result = codes(lottieWithUnnamedLayers);
+    expect(result).toContain("UNNAMED_LAYERS");
+    expect(result).toContain("MISSING_MARKERS");
+  });
+
+  it("does not over-report on a minimal clean file", () => {
+    const result = codes(minimalLottie);
+    expect(result).not.toContain("EMBEDDED_IMAGES");
+    expect(result).not.toContain("EXPRESSIONS");
+    expect(result).not.toContain("HIDDEN_LAYERS");
+    expect(result).not.toContain("LARGE_IMAGE_RESIZE");
+  });
+
+  it("attaches related layer indexes for hidden/expression detections", () => {
+    const metadata = extractMetadata(complexLottie);
+    const layers = analyzeLayers(complexLottie);
+    const scan = scanLottie(complexLottie);
+    const suggestions = buildOptimizationSuggestions({
+      metadata,
+      layers: layers.layers,
+      scan,
+    });
+    const hidden = suggestions.find((s) => s.code === "HIDDEN_LAYERS");
+    expect(hidden?.relatedLayerIndexes.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/lottie-analyzer/optimization.ts
+++ b/src/lib/lottie-analyzer/optimization.ts
@@ -1,0 +1,162 @@
+import { DeepScanResult } from "./scan";
+import { AnalyzedLayer, LottieMetadata, OptimizationSuggestion } from "./types";
+
+const UNNAMED_DEFAULT_PATTERN = /^(Layer \d+|Shape Layer \d+|Null \d+|Solid \d+|새 컴포지션 \d+|컴포지션 \d+)$/u;
+
+const LARGE_IMAGE_THRESHOLD_PX = 2000;
+
+interface BuildSuggestionsInput {
+  metadata: LottieMetadata;
+  layers: AnalyzedLayer[];
+  scan: DeepScanResult;
+  targetDimensions?: { width: number | null; height: number | null };
+}
+
+export function buildOptimizationSuggestions(
+  input: BuildSuggestionsInput,
+): OptimizationSuggestion[] {
+  const { metadata, layers, scan } = input;
+  const suggestions: OptimizationSuggestion[] = [];
+  const targetW = input.targetDimensions?.width ?? metadata.width;
+  const targetH = input.targetDimensions?.height ?? metadata.height;
+
+  const embeddedRatio =
+    metadata.imageAssetCount > 0
+      ? metadata.embeddedImageCount / metadata.imageAssetCount
+      : 0;
+  if (metadata.embeddedImageCount > 0) {
+    suggestions.push({
+      code: "EMBEDDED_IMAGES",
+      severity: embeddedRatio >= 0.5 ? "warning" : "info",
+      what: "embeddedImages.what",
+      why: "embeddedImages.why",
+      how: "embeddedImages.how",
+      relatedLayerIndexes: [],
+      relatedAssetIds: Array.from(scan.assetStats.entries())
+        .filter(([, v]) => v.embedded)
+        .map(([id]) => id),
+      metric: metadata.embeddedImageCount,
+    });
+  }
+
+  const unnamedLayers = layers.filter((l) =>
+    UNNAMED_DEFAULT_PATTERN.test(l.name.trim()),
+  );
+  if (unnamedLayers.length > 0) {
+    suggestions.push({
+      code: "UNNAMED_LAYERS",
+      severity: unnamedLayers.length >= 10 ? "warning" : "info",
+      what: "unnamedLayers.what",
+      why: "unnamedLayers.why",
+      how: "unnamedLayers.how",
+      relatedLayerIndexes: unnamedLayers.map((l) => l.index),
+      relatedAssetIds: [],
+      metric: unnamedLayers.length,
+    });
+  }
+
+  if (scan.totalExpressions > 0) {
+    suggestions.push({
+      code: "EXPRESSIONS",
+      severity: scan.totalExpressions >= 5 ? "warning" : "info",
+      what: "expressions.what",
+      why: "expressions.why",
+      how: "expressions.how",
+      relatedLayerIndexes: Array.from(scan.expressionLayerIndexes),
+      relatedAssetIds: [],
+      metric: scan.totalExpressions,
+    });
+  }
+
+  const hiddenLayers = layers.filter((l) => l.isHidden);
+  if (hiddenLayers.length > 0) {
+    suggestions.push({
+      code: "HIDDEN_LAYERS",
+      severity: "info",
+      what: "hiddenLayers.what",
+      why: "hiddenLayers.why",
+      how: "hiddenLayers.how",
+      relatedLayerIndexes: hiddenLayers.map((l) => l.index),
+      relatedAssetIds: [],
+      metric: hiddenLayers.length,
+    });
+  }
+
+  if (scan.totalDuplicateShapePaths > 0) {
+    suggestions.push({
+      code: "DUPLICATE_SHAPE_PATHS",
+      severity: "info",
+      what: "duplicateShapePaths.what",
+      why: "duplicateShapePaths.why",
+      how: "duplicateShapePaths.how",
+      relatedLayerIndexes: Array.from(scan.duplicateShapePathLayerIndexes),
+      relatedAssetIds: [],
+      metric: scan.totalDuplicateShapePaths,
+    });
+  }
+
+  const excessiveKeyframeLayers: number[] = [];
+  let totalExcessive = 0;
+  for (const [idx, count] of scan.keyframeCountByLayer.entries()) {
+    if (count >= 100) {
+      excessiveKeyframeLayers.push(idx);
+      totalExcessive += count;
+    }
+  }
+  if (excessiveKeyframeLayers.length > 0 || scan.totalKeyframes >= 500) {
+    suggestions.push({
+      code: "EXCESSIVE_KEYFRAMES",
+      severity:
+        scan.totalKeyframes >= 1000 || excessiveKeyframeLayers.length >= 5
+          ? "warning"
+          : "info",
+      what: "excessiveKeyframes.what",
+      why: "excessiveKeyframes.why",
+      how: "excessiveKeyframes.how",
+      relatedLayerIndexes: excessiveKeyframeLayers,
+      relatedAssetIds: [],
+      metric: totalExcessive > 0 ? totalExcessive : scan.totalKeyframes,
+    });
+  }
+
+  const oversizedAssets: string[] = [];
+  for (const [id, stats] of scan.assetStats.entries()) {
+    if (!stats.width || !stats.height) continue;
+    if (!targetW || !targetH) {
+      if (stats.width >= LARGE_IMAGE_THRESHOLD_PX || stats.height >= LARGE_IMAGE_THRESHOLD_PX) {
+        oversizedAssets.push(id);
+      }
+      continue;
+    }
+    if (stats.width > targetW * 2 || stats.height > targetH * 2) {
+      oversizedAssets.push(id);
+    }
+  }
+  if (oversizedAssets.length > 0) {
+    suggestions.push({
+      code: "LARGE_IMAGE_RESIZE",
+      severity: "warning",
+      what: "largeImageResize.what",
+      why: "largeImageResize.why",
+      how: "largeImageResize.how",
+      relatedLayerIndexes: [],
+      relatedAssetIds: oversizedAssets,
+      metric: oversizedAssets.length,
+    });
+  }
+
+  if (metadata.markerCount === 0 && metadata.totalFrames && metadata.totalFrames > 0) {
+    suggestions.push({
+      code: "MISSING_MARKERS",
+      severity: "info",
+      what: "missingMarkers.what",
+      why: "missingMarkers.why",
+      how: "missingMarkers.how",
+      relatedLayerIndexes: [],
+      relatedAssetIds: [],
+      metric: 0,
+    });
+  }
+
+  return suggestions;
+}

--- a/src/lib/lottie-analyzer/performance.test.ts
+++ b/src/lib/lottie-analyzer/performance.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { extractMetadata } from "./metadata";
+import {
+  computePerformanceScore,
+  gradeFromScore,
+  scoreEmbeddedImages,
+  scoreExpressions,
+  scoreFrameRate,
+  scoreLayerCount,
+} from "./performance";
+import { scanLottie } from "./scan";
+import { analyzeLayers } from "./layers";
+
+describe("scoring primitives", () => {
+  it("decreases score as layer count grows", () => {
+    expect(scoreLayerCount(5)).toBe(100);
+    expect(scoreLayerCount(50)).toBe(70);
+    expect(scoreLayerCount(200)).toBe(10);
+  });
+
+  it("penalizes expressions", () => {
+    expect(scoreExpressions(0)).toBe(100);
+    expect(scoreExpressions(3)).toBe(80);
+    expect(scoreExpressions(30)).toBe(10);
+  });
+
+  it("penalizes embedded images (linear)", () => {
+    expect(scoreEmbeddedImages(0)).toBe(100);
+    expect(scoreEmbeddedImages(5)).toBeCloseTo(50, 5);
+    expect(scoreEmbeddedImages(10)).toBe(0);
+  });
+
+  it("penalizes very high framerates", () => {
+    expect(scoreFrameRate(24)).toBe(100);
+    expect(scoreFrameRate(60)).toBe(70);
+    expect(scoreFrameRate(240)).toBe(20);
+  });
+
+  it("grades scores correctly", () => {
+    expect(gradeFromScore(95)).toBe("A");
+    expect(gradeFromScore(80)).toBe("B");
+    expect(gradeFromScore(65)).toBe("C");
+    expect(gradeFromScore(50)).toBe("D");
+    expect(gradeFromScore(10)).toBe("F");
+  });
+});
+
+describe("computePerformanceScore", () => {
+  function score(data: typeof minimalLottie) {
+    const metadata = extractMetadata(data);
+    const layers = analyzeLayers(data);
+    const scan = scanLottie(data);
+    const totalEffects = layers.layers.reduce((s, l) => s + l.effectCount, 0);
+    const totalMasks = layers.layers.reduce((s, l) => s + l.maskCount, 0);
+    return computePerformanceScore({ metadata, scan, totalEffects, totalMasks });
+  }
+
+  it("gives a high score to a minimal file", () => {
+    const result = score(minimalLottie);
+    expect(result.score).toBeGreaterThanOrEqual(90);
+    expect(result.grade).toBe("A");
+    expect(result.breakdown).toHaveLength(7);
+  });
+
+  it("gives a worse score to a heavy file", () => {
+    const result = score(complexLottie);
+    expect(result.score).toBeLessThan(score(minimalLottie).score);
+  });
+
+  it("breakdown contributions sum roughly to the score", () => {
+    const result = score(complexLottie);
+    const total = result.breakdown.reduce((s, m) => s + m.contribution, 0);
+    expect(Math.round(total)).toBe(result.score);
+  });
+});

--- a/src/lib/lottie-analyzer/performance.ts
+++ b/src/lib/lottie-analyzer/performance.ts
@@ -1,0 +1,168 @@
+import { DeepScanResult } from "./scan";
+import {
+  LottieMetadata,
+  PerformanceGrade,
+  PerformanceMetricBreakdown,
+  PerformanceScore,
+} from "./types";
+
+interface MetricInput {
+  key: string;
+  weight: number;
+  rawValue: number;
+  score: number;
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function linearInverseScore(value: number, worstAt: number): number {
+  if (value <= 0) return 100;
+  if (value >= worstAt) return 0;
+  return clamp(100 - (value / worstAt) * 100, 0, 100);
+}
+
+export function scoreLayerCount(count: number): number {
+  if (count <= 10) return 100;
+  if (count <= 30) return 85;
+  if (count <= 60) return 70;
+  if (count <= 100) return 50;
+  if (count <= 150) return 30;
+  return 10;
+}
+
+export function scoreExpressions(totalExpressions: number): number {
+  if (totalExpressions === 0) return 100;
+  if (totalExpressions <= 3) return 80;
+  if (totalExpressions <= 10) return 55;
+  if (totalExpressions <= 25) return 30;
+  return 10;
+}
+
+export function scoreEffects(totalEffects: number): number {
+  if (totalEffects === 0) return 100;
+  if (totalEffects <= 3) return 80;
+  if (totalEffects <= 8) return 55;
+  if (totalEffects <= 15) return 30;
+  return 10;
+}
+
+export function scoreMasks(totalMasks: number): number {
+  if (totalMasks === 0) return 100;
+  if (totalMasks <= 3) return 85;
+  if (totalMasks <= 8) return 60;
+  if (totalMasks <= 15) return 35;
+  return 15;
+}
+
+export function score3D(is3D: boolean): number {
+  return is3D ? 40 : 100;
+}
+
+export function scoreEmbeddedImages(count: number): number {
+  return linearInverseScore(count, 10);
+}
+
+export function scoreFrameRate(fr: number | null): number {
+  if (fr === null) return 70;
+  if (fr <= 24) return 100;
+  if (fr <= 30) return 95;
+  if (fr <= 60) return 70;
+  if (fr <= 120) return 40;
+  return 20;
+}
+
+export function gradeFromScore(score: number): PerformanceGrade {
+  if (score >= 90) return "A";
+  if (score >= 75) return "B";
+  if (score >= 60) return "C";
+  if (score >= 45) return "D";
+  return "F";
+}
+
+const WEIGHTS = {
+  layerCount: 0.2,
+  expressions: 0.2,
+  effects: 0.15,
+  masks: 0.15,
+  is3D: 0.1,
+  embeddedImages: 0.1,
+  frameRate: 0.1,
+};
+
+export interface ScorePerformanceInput {
+  metadata: LottieMetadata;
+  scan: DeepScanResult;
+  totalEffects: number;
+  totalMasks: number;
+}
+
+export function computePerformanceScore(input: ScorePerformanceInput): PerformanceScore {
+  const { metadata, scan, totalEffects, totalMasks } = input;
+
+  const metrics: MetricInput[] = [
+    {
+      key: "layerCount",
+      weight: WEIGHTS.layerCount,
+      rawValue: metadata.layerCount,
+      score: scoreLayerCount(metadata.layerCount),
+    },
+    {
+      key: "expressions",
+      weight: WEIGHTS.expressions,
+      rawValue: scan.totalExpressions,
+      score: scoreExpressions(scan.totalExpressions),
+    },
+    {
+      key: "effects",
+      weight: WEIGHTS.effects,
+      rawValue: totalEffects,
+      score: scoreEffects(totalEffects),
+    },
+    {
+      key: "masks",
+      weight: WEIGHTS.masks,
+      rawValue: totalMasks,
+      score: scoreMasks(totalMasks),
+    },
+    {
+      key: "is3D",
+      weight: WEIGHTS.is3D,
+      rawValue: metadata.is3D ? 1 : 0,
+      score: score3D(metadata.is3D),
+    },
+    {
+      key: "embeddedImages",
+      weight: WEIGHTS.embeddedImages,
+      rawValue: metadata.embeddedImageCount,
+      score: scoreEmbeddedImages(metadata.embeddedImageCount),
+    },
+    {
+      key: "frameRate",
+      weight: WEIGHTS.frameRate,
+      rawValue: metadata.frameRate ?? 0,
+      score: scoreFrameRate(metadata.frameRate),
+    },
+  ];
+
+  let total = 0;
+  const breakdown: PerformanceMetricBreakdown[] = metrics.map((m) => {
+    const contribution = m.score * m.weight;
+    total += contribution;
+    return {
+      key: m.key,
+      weight: m.weight,
+      rawValue: m.rawValue,
+      score: m.score,
+      contribution,
+    };
+  });
+
+  const finalScore = Math.round(total);
+  return {
+    score: finalScore,
+    grade: gradeFromScore(finalScore),
+    breakdown,
+  };
+}

--- a/src/lib/lottie-analyzer/scan.ts
+++ b/src/lib/lottie-analyzer/scan.ts
@@ -1,0 +1,215 @@
+import {
+  LottieAsset,
+  LottieJson,
+  LottieLayer,
+  LottieShape,
+} from "./types";
+
+export interface DeepScanResult {
+  expressionLayerIndexes: Set<number>;
+  totalExpressions: number;
+  keyframeCountByLayer: Map<number, number>;
+  totalKeyframes: number;
+  duplicateShapePathLayerIndexes: Set<number>;
+  totalDuplicateShapePaths: number;
+  layerTextMap: Map<number, boolean>;
+  hasMergePathsLayerIndexes: Set<number>;
+  hasGradientStrokeLayerIndexes: Set<number>;
+  hasTrimPathLayerIndexes: Set<number>;
+  hasMatteLayerIndexes: Set<number>;
+  hasPerCharTextLayerIndexes: Set<number>;
+  assetStats: Map<string, { width: number | null; height: number | null; embedded: boolean }>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function countKeyframes(value: unknown): number {
+  if (!isPlainObject(value)) return 0;
+  const record = value as Record<string, unknown>;
+  if (Array.isArray(record.k) && record.k.length > 1 && isPlainObject(record.k[0])) {
+    return record.k.length;
+  }
+  return 0;
+}
+
+function walkForExpressionsAndKeyframes(
+  node: unknown,
+  layerIdx: number,
+  result: DeepScanResult,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walkForExpressionsAndKeyframes(item, layerIdx, result);
+    }
+    return;
+  }
+  if (!isPlainObject(node)) return;
+
+  const record = node as Record<string, unknown>;
+
+  if (typeof record.x === "string" && record.x.length > 0) {
+    result.expressionLayerIndexes.add(layerIdx);
+    result.totalExpressions += 1;
+  }
+
+  const kfCount = countKeyframes(record);
+  if (kfCount > 0) {
+    const prev = result.keyframeCountByLayer.get(layerIdx) ?? 0;
+    result.keyframeCountByLayer.set(layerIdx, prev + kfCount);
+    result.totalKeyframes += kfCount;
+  }
+
+  for (const key of Object.keys(record)) {
+    walkForExpressionsAndKeyframes(record[key], layerIdx, result);
+  }
+}
+
+function collectShapePaths(shapes: LottieShape[] | undefined, out: string[]): void {
+  if (!Array.isArray(shapes)) return;
+  for (const shape of shapes) {
+    if (!shape || typeof shape !== "object") continue;
+    if (shape.ty === "sh" && shape.ks) {
+      try {
+        out.push(JSON.stringify(shape.ks));
+      } catch {
+        // ignore circular structure
+      }
+    }
+    if (Array.isArray(shape.it)) {
+      collectShapePaths(shape.it as LottieShape[], out);
+    }
+  }
+}
+
+function detectDuplicateShapePaths(layer: LottieLayer): number {
+  if (!Array.isArray(layer.shapes)) return 0;
+  const paths: string[] = [];
+  collectShapePaths(layer.shapes, paths);
+  if (paths.length < 2) return 0;
+  const seen = new Map<string, number>();
+  let duplicates = 0;
+  for (const p of paths) {
+    const n = (seen.get(p) ?? 0) + 1;
+    seen.set(p, n);
+    if (n >= 2) duplicates += 1;
+  }
+  return duplicates;
+}
+
+function detectFeaturesFromShapes(
+  shapes: LottieShape[] | undefined,
+  detected: {
+    mergePaths: boolean;
+    gradientStroke: boolean;
+    trimPath: boolean;
+  },
+): void {
+  if (!Array.isArray(shapes)) return;
+  for (const shape of shapes) {
+    if (!shape || typeof shape !== "object") continue;
+    if (shape.ty === "mm") detected.mergePaths = true;
+    if (shape.ty === "gs") detected.gradientStroke = true;
+    if (shape.ty === "tm") detected.trimPath = true;
+    if (Array.isArray(shape.it)) {
+      detectFeaturesFromShapes(shape.it as LottieShape[], detected);
+    }
+  }
+}
+
+function detectPerCharText(layer: LottieLayer): boolean {
+  if (layer.ty !== 5) return false;
+  const t = layer.t as Record<string, unknown> | undefined;
+  if (!isPlainObject(t)) return false;
+  const m = t.m as Record<string, unknown> | undefined;
+  if (!isPlainObject(m)) return false;
+  const g = m.g;
+  if (typeof g === "number" && g > 1) return true;
+  const a = t.a;
+  if (Array.isArray(a) && a.length > 0) return true;
+  return false;
+}
+
+function detectMatte(layer: LottieLayer): boolean {
+  if (typeof layer.tt === "number" && layer.tt > 0) return true;
+  if (typeof layer.td === "number" && layer.td > 0) return true;
+  return false;
+}
+
+function collectAssetStats(
+  data: LottieJson,
+  result: DeepScanResult,
+): void {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  for (const asset of assets) {
+    if (!asset.id) continue;
+    const isImage = typeof asset.p === "string" && asset.p.length > 0;
+    if (!isImage) continue;
+    const embedded =
+      asset.e === 1 ||
+      (typeof asset.p === "string" && asset.p.startsWith("data:"));
+    result.assetStats.set(asset.id, {
+      width: typeof asset.w === "number" ? asset.w : null,
+      height: typeof asset.h === "number" ? asset.h : null,
+      embedded,
+    });
+  }
+}
+
+export function scanLottie(data: LottieJson): DeepScanResult {
+  const result: DeepScanResult = {
+    expressionLayerIndexes: new Set<number>(),
+    totalExpressions: 0,
+    keyframeCountByLayer: new Map<number, number>(),
+    totalKeyframes: 0,
+    duplicateShapePathLayerIndexes: new Set<number>(),
+    totalDuplicateShapePaths: 0,
+    layerTextMap: new Map<number, boolean>(),
+    hasMergePathsLayerIndexes: new Set<number>(),
+    hasGradientStrokeLayerIndexes: new Set<number>(),
+    hasTrimPathLayerIndexes: new Set<number>(),
+    hasMatteLayerIndexes: new Set<number>(),
+    hasPerCharTextLayerIndexes: new Set<number>(),
+    assetStats: new Map(),
+  };
+
+  const layers: LottieLayer[] = Array.isArray(data.layers) ? data.layers : [];
+  const precompAssets: LottieAsset[] = Array.isArray(data.assets)
+    ? data.assets.filter((a) => Array.isArray(a.layers))
+    : [];
+
+  const allLayers: LottieLayer[] = [...layers];
+  for (const asset of precompAssets) {
+    if (Array.isArray(asset.layers)) allLayers.push(...asset.layers);
+  }
+
+  for (let i = 0; i < allLayers.length; i += 1) {
+    const layer = allLayers[i];
+    const layerIdx = typeof layer.ind === "number" ? layer.ind : i;
+
+    walkForExpressionsAndKeyframes(layer, layerIdx, result);
+
+    const dupCount = detectDuplicateShapePaths(layer);
+    if (dupCount > 0) {
+      result.duplicateShapePathLayerIndexes.add(layerIdx);
+      result.totalDuplicateShapePaths += dupCount;
+    }
+
+    const features = {
+      mergePaths: false,
+      gradientStroke: false,
+      trimPath: false,
+    };
+    detectFeaturesFromShapes(layer.shapes, features);
+    if (features.mergePaths) result.hasMergePathsLayerIndexes.add(layerIdx);
+    if (features.gradientStroke) result.hasGradientStrokeLayerIndexes.add(layerIdx);
+    if (features.trimPath) result.hasTrimPathLayerIndexes.add(layerIdx);
+
+    if (detectMatte(layer)) result.hasMatteLayerIndexes.add(layerIdx);
+    if (detectPerCharText(layer)) result.hasPerCharTextLayerIndexes.add(layerIdx);
+  }
+
+  collectAssetStats(data, result);
+  return result;
+}

--- a/src/lib/lottie-analyzer/types.ts
+++ b/src/lib/lottie-analyzer/types.ts
@@ -1,0 +1,216 @@
+export type LayerTypeCode = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export const LAYER_TYPE_NAMES: Record<LayerTypeCode, string> = {
+  0: "Precomp",
+  1: "Solid",
+  2: "Image",
+  3: "Null",
+  4: "Shape",
+  5: "Text",
+  6: "Audio",
+};
+
+export interface LottieAsset {
+  id?: string;
+  w?: number;
+  h?: number;
+  u?: string;
+  p?: string;
+  e?: number;
+  layers?: LottieLayer[];
+  [key: string]: unknown;
+}
+
+export interface LottieMarker {
+  tm?: number;
+  cm?: string;
+  dr?: number;
+  [key: string]: unknown;
+}
+
+export interface LottieLayerTransform {
+  p?: { k?: unknown } | unknown;
+  a?: { k?: unknown } | unknown;
+  s?: { k?: unknown } | unknown;
+  r?: { k?: unknown } | unknown;
+  o?: { k?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface LottieShape {
+  ty?: string;
+  it?: LottieShape[];
+  ks?: { k?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface LottieLayerEffect {
+  ty?: number;
+  nm?: string;
+  [key: string]: unknown;
+}
+
+export interface LottieLayerMask {
+  mode?: string;
+  [key: string]: unknown;
+}
+
+export interface LottieLayer {
+  ty: LayerTypeCode;
+  nm?: string;
+  ind?: number;
+  parent?: number;
+  ip?: number;
+  op?: number;
+  st?: number;
+  sr?: number;
+  bm?: number;
+  ddd?: 0 | 1;
+  hd?: boolean;
+  ks?: LottieLayerTransform;
+  shapes?: LottieShape[];
+  ef?: LottieLayerEffect[];
+  masksProperties?: LottieLayerMask[];
+  hasMask?: boolean;
+  refId?: string;
+  t?: { d?: unknown; m?: unknown; p?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface LottieJson {
+  v?: string;
+  fr?: number;
+  ip?: number;
+  op?: number;
+  w?: number;
+  h?: number;
+  nm?: string;
+  ddd?: 0 | 1;
+  assets?: LottieAsset[];
+  layers?: LottieLayer[];
+  markers?: LottieMarker[];
+  meta?: {
+    g?: string;
+    a?: string;
+    k?: string;
+    d?: string;
+    tc?: string;
+    [key: string]: unknown;
+  };
+  chars?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface LottieMetadata {
+  version: string | null;
+  generator: string | null;
+  width: number | null;
+  height: number | null;
+  frameRate: number | null;
+  inPoint: number | null;
+  outPoint: number | null;
+  totalFrames: number | null;
+  durationSeconds: number | null;
+  layerCount: number;
+  layerCountsByType: Record<string, number>;
+  assetCount: number;
+  imageAssetCount: number;
+  precompAssetCount: number;
+  embeddedImageCount: number;
+  markerCount: number;
+  fileSizeBytes: number | null;
+  is3D: boolean;
+}
+
+export interface AnalyzedLayer {
+  index: number;
+  name: string;
+  typeCode: LayerTypeCode;
+  typeName: string;
+  startFrame: number;
+  endFrame: number;
+  blendMode: number;
+  is3D: boolean;
+  effectCount: number;
+  maskCount: number;
+  parent: number | null;
+  isHidden: boolean;
+}
+
+export interface LayerTreeNode extends AnalyzedLayer {
+  children: LayerTreeNode[];
+}
+
+export interface LayerAnalysisResult {
+  layers: AnalyzedLayer[];
+  tree: LayerTreeNode[];
+}
+
+export type PerformanceGrade = "A" | "B" | "C" | "D" | "F";
+
+export interface PerformanceMetricBreakdown {
+  key: string;
+  weight: number;
+  rawValue: number;
+  score: number;
+  contribution: number;
+}
+
+export interface PerformanceScore {
+  score: number;
+  grade: PerformanceGrade;
+  breakdown: PerformanceMetricBreakdown[];
+}
+
+export type SuggestionSeverity = "info" | "warning" | "error";
+
+export type SuggestionCode =
+  | "EMBEDDED_IMAGES"
+  | "UNNAMED_LAYERS"
+  | "EXPRESSIONS"
+  | "HIDDEN_LAYERS"
+  | "DUPLICATE_SHAPE_PATHS"
+  | "EXCESSIVE_KEYFRAMES"
+  | "LARGE_IMAGE_RESIZE"
+  | "MISSING_MARKERS";
+
+export interface OptimizationSuggestion {
+  code: SuggestionCode;
+  severity: SuggestionSeverity;
+  what: string;
+  why: string;
+  how: string;
+  relatedLayerIndexes: number[];
+  relatedAssetIds: string[];
+  metric?: number;
+}
+
+export type PlatformKey = "web" | "ios" | "android";
+
+export type PlatformSupportLevel = "supported" | "partial" | "unsupported";
+
+export interface PlatformFeatureSupport {
+  feature: string;
+  web: PlatformSupportLevel;
+  ios: PlatformSupportLevel;
+  android: PlatformSupportLevel;
+  detectedInFile: boolean;
+  relatedLayerIndexes: number[];
+}
+
+export interface PlatformCompatibility {
+  features: PlatformFeatureSupport[];
+  summary: Record<PlatformKey, {
+    overall: PlatformSupportLevel;
+    unsupportedCount: number;
+    partialCount: number;
+  }>;
+}
+
+export interface LottieAnalysisResult {
+  metadata: LottieMetadata;
+  layers: LayerAnalysisResult;
+  performance: PerformanceScore;
+  suggestions: OptimizationSuggestion[];
+  compatibility: PlatformCompatibility;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Summary

> JSO-1의 Phase A로, Lottie JSON 분석 전용 유틸 모듈(`src/lib/lottie-analyzer/`)과 단위 테스트 기반(vitest)을 먼저 추가한다.

## 📋 Changes

- `./package.json`, `./package-lock.json`: vitest/@vitest/coverage-v8 devDependency 추가, `npm test`는 vitest로, Playwright는 `npm run test:e2e`로 분리
- `./vitest.config.ts`: `src/**/*.test.ts` 대상 Node 환경 설정, `@/*` alias 매핑
- `./src/lib/lottie-analyzer/types.ts`: Lottie JSON/분석 결과 공통 타입 정의 (메타데이터, 레이어, 성능 점수, 제안, 호환성)
- `./src/lib/lottie-analyzer/metadata.ts`: 스펙 버전, AE 버전(`meta.g`), 차원, 프레임레이트, 총 프레임/재생시간, 레이어 수/타입별 집계, 에셋/이미지/프리콤프/임베디드 이미지/마커 수, 파일 크기, 3D 여부 추출 + 포맷터 (`formatDuration`, `formatFileSize`)
- `./src/lib/lottie-analyzer/layers.ts`: 레이어별 이름/타입/프레임 범위/블렌딩/3D/이펙트·마스크 수 분석, 부모-자식 관계 트리 빌드, blend mode 이름 매핑
- `./src/lib/lottie-analyzer/scan.ts`: 재귀 스캔으로 Expression(`x`)·키프레임·중복 shape path 감지, Merge Paths/Gradient Stroke/Trim Path/Matte/Per-char Text 플래그 수집, 이미지 에셋 통계(차원/임베디드 여부)
- `./src/lib/lottie-analyzer/performance.ts`: 7개 메트릭 가중합산(레이어 20 / Expression 20 / 이펙트 15 / 마스크 15 / 3D 10 / 임베디드 이미지 10 / 프레임레이트 10)으로 0~100 점수와 A~F 등급, 메트릭별 기여도 breakdown
- `./src/lib/lottie-analyzer/optimization.ts`: 이슈에서 요구한 8개 감지 규칙(임베디드 이미지 비율, 기본명 레이어, Expression, 숨겨진 레이어, 중복 shape path, 과도한 키프레임, 고해상도 이미지 리사이즈, 마커 부재) + 관련 레이어/에셋 매핑
- `./src/lib/lottie-analyzer/compatibility.ts`: Airbnb 공식 매트릭스 기반 Web/iOS/Android 지원 수준(supported/partial/unsupported) + 파일 내 해당 기능 탐지 여부
- `./src/lib/lottie-analyzer/index.ts`: `analyzeLottie()` 엔트리와 public API export
- `./src/lib/lottie-analyzer/__fixtures__.ts`, `*.test.ts`: 각 모듈 단위 테스트 (총 30 케이스)

## 🧠 Context & Background

JSO-1은 AdSense \"Thin Content\" 대응을 위해 \"업로드 → 미리보기 → 이탈\" 구조를 \"업로드 → 자동 분석/진단/제안\" 콘텐츠 사이트로 전환하는 작업이다. 전체 범위가 매우 크므로 Phase 단위(A: 유틸 → B: 분석 UI → C: 플레이어/배경/스니펫 → D: i18n/테마/반응형)로 분할했고, 이 PR은 Phase A로 UI가 올라타기 전 순수 로직 계층을 먼저 확정한다.

## ✅ How to Test

1. `npm install`
2. `npm test` → vitest 30 케이스 통과 확인 (metadata / layers / performance / optimization / compatibility / index)
3. `npx tsc --noEmit` 타입 에러 없음
4. `npm run lint` ESLint 경고/에러 없음

## 🔗 Related Issues

- Related: JSO-1 (Phase A / 4단계 분할 중 1단계)

## 🙌 Additional Notes

- UI/i18n/다크모드는 후속 Phase에서 붙는다. 이 PR의 `optimization.ts`가 반환하는 `what/why/how` 필드는 Phase D에서 i18n 키에 매핑될 예정이라 현재는 메시지 키 문자열만 담고 있다.
- 기존 `tests/animation.test.ts`는 Playwright e2e이므로 `npm run test:e2e`로 그대로 동작한다.