### PR TITLE
feature/JSO-1-phase-b-sections-1-5

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,152 @@
 {
+  "analysis": {
+    "metadata": {
+      "title": "Animation Metadata",
+      "subtitle": "Auto-extracted facts about your Lottie file",
+      "version": "Lottie Spec",
+      "dimensions": "Dimensions",
+      "frameRate": "Frame Rate",
+      "totalFrames": "Total Frames",
+      "duration": "Duration",
+      "layerCount": "Layer Count",
+      "assetCount": "Assets",
+      "assetBreakdown": "{images} images · {precomps} precomps",
+      "embeddedImages": "Embedded Images",
+      "markers": "Markers",
+      "fileSize": "File Size",
+      "is3D": "3D Layers",
+      "yes": "Yes",
+      "no": "No",
+      "layerTypesHeading": "Layers by Type"
+    },
+    "layers": {
+      "title": "Layer Breakdown",
+      "subtitle": "{count} layers detected",
+      "listMode": "List",
+      "treeMode": "Tree",
+      "columnName": "Name",
+      "columnType": "Type",
+      "columnFrames": "Frames",
+      "columnBlend": "Blend",
+      "column3D": "3D",
+      "columnEffects": "FX",
+      "columnMasks": "Masks",
+      "empty": "No layers in this animation.",
+      "pageStatus": "Showing {from}–{to} of {total}",
+      "prev": "Prev",
+      "next": "Next",
+      "clearHighlight": "Clear highlight"
+    },
+    "performance": {
+      "title": "Performance Score",
+      "subtitle": "Weighted signals that predict runtime cost on low-end devices",
+      "breakdownHeading": "Metric contribution",
+      "metric": {
+        "layerCount": "Layer count",
+        "expressions": "Expression usage",
+        "effects": "Effects",
+        "masks": "Masks",
+        "is3D": "3D layers",
+        "embeddedImages": "Embedded images",
+        "frameRate": "Frame rate"
+      },
+      "rawValue": "raw: {value}"
+    },
+    "optimization": {
+      "title": "Optimization Suggestions",
+      "subtitle": "{count} issues worth reviewing",
+      "allClear": "No optimization issues detected — this file is in great shape.",
+      "severity": {
+        "info": "info",
+        "warning": "warning",
+        "error": "error"
+      },
+      "what": "What",
+      "why": "Why it matters",
+      "how": "How to fix",
+      "relatedLayers": "Jump to layer",
+      "codes": {
+        "embeddedImages": {
+          "title": "Embedded raster images",
+          "metric": "{value} embedded",
+          "what": "Some images are base64-embedded directly in the JSON.",
+          "why": "Embedded images make the JSON much larger, block fast decoding, and defeat browser image caching.",
+          "how": "Export images as external assets or replace them with vector shape layers when possible."
+        },
+        "unnamedLayers": {
+          "title": "Unnamed / default-named layers",
+          "metric": "{value} layers",
+          "what": "Layers still use AE default names like \"Shape Layer 1\".",
+          "why": "Without meaningful names the JSON is hard to inspect and runtime platforms cannot target individual layers.",
+          "how": "Rename layers in After Effects to describe what they represent before exporting."
+        },
+        "expressions": {
+          "title": "Expression usage",
+          "metric": "{value} expressions",
+          "what": "Expressions (`x` fields) are used in one or more layers.",
+          "why": "Mobile Lottie renderers do not execute expressions and will silently drop the animation.",
+          "how": "Pre-bake expressions into keyframes via \"Convert Expression to Keyframes\" or Lottie's Bodymovin baker."
+        },
+        "hiddenLayers": {
+          "title": "Hidden layers shipping in the file",
+          "metric": "{value} hidden",
+          "what": "Layers are marked hidden (`hd: true`) but still included in the JSON.",
+          "why": "Hidden layers add parse/render cost for something the user never sees.",
+          "how": "Delete them in After Effects if they are not needed for runtime logic."
+        },
+        "duplicateShapePaths": {
+          "title": "Duplicate shape paths",
+          "metric": "{value} duplicates",
+          "what": "The same shape path appears more than once in the same layer.",
+          "why": "Duplicate geometry doubles draw-calls with no visual benefit.",
+          "how": "Combine into a single shape or reuse via a precomp."
+        },
+        "excessiveKeyframes": {
+          "title": "Excessive keyframes",
+          "metric": "{value} keyframes",
+          "what": "One or more layers contain very dense keyframe data.",
+          "why": "Large keyframe arrays increase JSON size and CPU cost on low-end devices.",
+          "how": "Simplify the animation curve, drop non-essential keyframes, or use expressions pre-baked at a lower sample rate."
+        },
+        "largeImageResize": {
+          "title": "Oversized image assets",
+          "metric": "{value} assets",
+          "what": "Some image assets are significantly larger than the composition.",
+          "why": "Shipping 2× or larger images wastes bandwidth and memory on every render.",
+          "how": "Resize the PNG/JPG to at most 2× the rendered dimensions before importing."
+        },
+        "missingMarkers": {
+          "title": "No markers defined",
+          "metric": "",
+          "what": "The animation has no named markers.",
+          "why": "Markers let developers jump to specific segments without guessing frame numbers.",
+          "how": "Add markers in After Effects for each meaningful segment (intro, loop, outro, etc.)."
+        }
+      }
+    },
+    "compatibility": {
+      "title": "Platform Compatibility",
+      "subtitle": "How this file behaves on Web, iOS, and Android Lottie runtimes",
+      "officialDoc": "Airbnb docs →",
+      "platforms": {
+        "web": "Web",
+        "ios": "iOS",
+        "android": "Android"
+      },
+      "levels": {
+        "supported": "Fully supported",
+        "partial": "Partial support",
+        "unsupported": "Not supported"
+      },
+      "issueBreakdown": "{unsupported} unsupported · {partial} partial",
+      "detectedIssues": "Detected issues on {platform}",
+      "noIssues": "No platform issues detected in this file.",
+      "columnFeature": "Feature",
+      "columnDetected": "In file",
+      "yes": "Yes",
+      "no": "No"
+    }
+  },
   "common": {
     "backToHome": "← Back to Home",
     "backToBlog": "← Back to Blog",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,4 +1,152 @@
 {
+  "analysis": {
+    "metadata": {
+      "title": "애니메이션 메타데이터",
+      "subtitle": "업로드한 Lottie 파일에서 자동 추출한 정보",
+      "version": "Lottie 스펙",
+      "dimensions": "크기",
+      "frameRate": "프레임레이트",
+      "totalFrames": "총 프레임 수",
+      "duration": "재생 시간",
+      "layerCount": "레이어 수",
+      "assetCount": "에셋",
+      "assetBreakdown": "이미지 {images}개 · 프리콤프 {precomps}개",
+      "embeddedImages": "임베디드 이미지",
+      "markers": "마커",
+      "fileSize": "파일 크기",
+      "is3D": "3D 레이어",
+      "yes": "있음",
+      "no": "없음",
+      "layerTypesHeading": "타입별 레이어"
+    },
+    "layers": {
+      "title": "레이어 분석",
+      "subtitle": "총 {count}개 레이어",
+      "listMode": "리스트",
+      "treeMode": "트리",
+      "columnName": "이름",
+      "columnType": "타입",
+      "columnFrames": "프레임",
+      "columnBlend": "블렌딩",
+      "column3D": "3D",
+      "columnEffects": "이펙트",
+      "columnMasks": "마스크",
+      "empty": "이 애니메이션에는 레이어가 없습니다.",
+      "pageStatus": "{from}–{to} / {total}",
+      "prev": "이전",
+      "next": "다음",
+      "clearHighlight": "하이라이트 해제"
+    },
+    "performance": {
+      "title": "성능 점수",
+      "subtitle": "저사양 기기 기준 런타임 비용을 예측하는 가중 지표",
+      "breakdownHeading": "메트릭별 기여도",
+      "metric": {
+        "layerCount": "레이어 수",
+        "expressions": "Expression 사용",
+        "effects": "이펙트",
+        "masks": "마스크",
+        "is3D": "3D 레이어",
+        "embeddedImages": "임베디드 이미지",
+        "frameRate": "프레임레이트"
+      },
+      "rawValue": "원시값: {value}"
+    },
+    "optimization": {
+      "title": "최적화 제안",
+      "subtitle": "{count}개 항목 검토 권장",
+      "allClear": "감지된 최적화 이슈가 없습니다 — 아주 깔끔한 파일입니다.",
+      "severity": {
+        "info": "정보",
+        "warning": "경고",
+        "error": "오류"
+      },
+      "what": "무엇이",
+      "why": "왜 중요한지",
+      "how": "어떻게 해결",
+      "relatedLayers": "관련 레이어로 이동",
+      "codes": {
+        "embeddedImages": {
+          "title": "JSON에 임베디드된 이미지",
+          "metric": "{value}개 임베디드",
+          "what": "일부 이미지가 base64로 JSON에 직접 포함되어 있습니다.",
+          "why": "임베디드 이미지는 JSON 용량을 크게 늘리고 디코딩을 지연시키며 브라우저 캐싱도 막습니다.",
+          "how": "이미지를 외부 에셋으로 내보내거나 가능하다면 벡터 Shape 레이어로 대체하세요."
+        },
+        "unnamedLayers": {
+          "title": "이름이 정리되지 않은 레이어",
+          "metric": "{value}개",
+          "what": "레이어가 \"Shape Layer 1\" 같은 AE 기본 이름 그대로입니다.",
+          "why": "의미 있는 이름이 없으면 JSON 디버깅이 어렵고 런타임에서 특정 레이어를 타겟팅할 수 없습니다.",
+          "how": "After Effects에서 내보내기 전에 레이어 이름을 역할에 맞게 변경하세요."
+        },
+        "expressions": {
+          "title": "Expression 사용",
+          "metric": "{value}개 Expression",
+          "what": "일부 레이어에 Expression(`x` 필드)이 사용되었습니다.",
+          "why": "iOS/Android Lottie 런타임은 Expression을 실행하지 않아 애니메이션이 조용히 누락됩니다.",
+          "how": "\"Convert Expression to Keyframes\" 또는 Bodymovin 베이커로 키프레임으로 변환하세요."
+        },
+        "hiddenLayers": {
+          "title": "숨겨진 레이어가 포함됨",
+          "metric": "{value}개 숨김",
+          "what": "`hd: true`로 표시된 레이어가 JSON에 여전히 포함되어 있습니다.",
+          "why": "보이지 않는 레이어도 파싱/렌더 비용이 발생합니다.",
+          "how": "런타임에서 사용하지 않는다면 After Effects에서 삭제 후 다시 내보내세요."
+        },
+        "duplicateShapePaths": {
+          "title": "중복 Shape Path",
+          "metric": "{value}개 중복",
+          "what": "같은 레이어 안에서 동일한 shape path가 두 번 이상 등장합니다.",
+          "why": "중복 지오메트리는 시각적 이득 없이 드로 콜을 두 배로 만듭니다.",
+          "how": "하나의 shape로 합치거나 precomp로 재사용하세요."
+        },
+        "excessiveKeyframes": {
+          "title": "과도한 키프레임",
+          "metric": "{value}개 키프레임",
+          "what": "일부 레이어의 키프레임 밀도가 매우 높습니다.",
+          "why": "키프레임 배열이 커지면 JSON 용량과 저사양 기기의 CPU 사용이 함께 증가합니다.",
+          "how": "애니메이션 커브를 단순화하거나 불필요한 키프레임을 제거하세요. 낮은 샘플링으로 다시 베이크하는 것도 방법입니다."
+        },
+        "largeImageResize": {
+          "title": "해상도가 과한 이미지 에셋",
+          "metric": "{value}개 에셋",
+          "what": "컴포지션보다 훨씬 큰 이미지 에셋이 포함되어 있습니다.",
+          "why": "2배 이상의 이미지는 매 렌더마다 대역폭과 메모리를 낭비합니다.",
+          "how": "임포트 전에 렌더 크기의 최대 2배 이하로 PNG/JPG를 리사이즈하세요."
+        },
+        "missingMarkers": {
+          "title": "마커가 없음",
+          "metric": "",
+          "what": "애니메이션에 명명된 마커가 전혀 없습니다.",
+          "why": "마커가 없으면 개발자가 프레임 번호를 추측해 세그먼트를 재생해야 합니다.",
+          "how": "After Effects에서 intro/loop/outro 등 의미 있는 구간마다 마커를 추가하세요."
+        }
+      }
+    },
+    "compatibility": {
+      "title": "플랫폼 호환성",
+      "subtitle": "Web / iOS / Android Lottie 런타임에서의 동작 지원 수준",
+      "officialDoc": "Airbnb 공식 문서 →",
+      "platforms": {
+        "web": "Web",
+        "ios": "iOS",
+        "android": "Android"
+      },
+      "levels": {
+        "supported": "완전 지원",
+        "partial": "부분 지원",
+        "unsupported": "미지원"
+      },
+      "issueBreakdown": "미지원 {unsupported}건 · 부분 지원 {partial}건",
+      "detectedIssues": "{platform}에서 감지된 이슈",
+      "noIssues": "이 파일에서 플랫폼 이슈가 감지되지 않았습니다.",
+      "columnFeature": "기능",
+      "columnDetected": "파일 내 사용",
+      "yes": "예",
+      "no": "아니오"
+    }
+  },
   "common": {
     "backToHome": "← 홈으로 돌아가기",
     "backToBlog": "← 블로그로 돌아가기",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,12 +4,10 @@ import { useState, useEffect, useRef, Suspense } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import type { AnimationItem, LottiePlayer } from "lottie-web";
+import { AnalysisResult } from "@/components/analysis/AnalysisResult";
+import type { LottieJson } from "@/lib/lottie-analyzer";
 
-interface AnimationData {
-  w?: number;
-  h?: number;
-  [key: string]: unknown;
-}
+type AnimationData = LottieJson;
 
 function LoadingFallback() {
   const t = useTranslations("common");
@@ -75,6 +73,7 @@ export default function Home() {
   }>({ width: 0, height: 0 });
 
   const [fileName, setFileName] = useState<string | null>(null);
+  const [fileSizeBytes, setFileSizeBytes] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -100,45 +99,33 @@ export default function Home() {
     };
   }, []);
 
+  const loadFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const result = e.target?.result as string;
+        if (result) {
+          const parsedData = JSON.parse(result) as AnimationData;
+          setAnimationData(parsedData);
+          setFileName(file.name);
+          setFileSizeBytes(file.size);
+        }
+      } catch (error) {
+        console.error("Invalid JSON file", error);
+      }
+    };
+    reader.readAsText(file);
+  };
+
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const result = e.target?.result as string;
-          if (result) {
-            const parsedData = JSON.parse(result) as AnimationData;
-            setAnimationData(parsedData);
-            setFileName(file.name);
-          }
-        } catch (error) {
-          console.error("Invalid JSON file", error);
-        }
-      };
-      reader.readAsText(file);
-    }
+    if (file) loadFile(file);
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     const file = event.dataTransfer.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const result = e.target?.result as string;
-          if (result) {
-            const parsedData = JSON.parse(result) as AnimationData;
-            setAnimationData(parsedData);
-            setFileName(file.name);
-          }
-        } catch (error) {
-          console.error("Invalid JSON file", error);
-        }
-      };
-      reader.readAsText(file);
-    }
+    if (file) loadFile(file);
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -212,6 +199,12 @@ export default function Home() {
           </p>
         </div>
       </section>
+
+      {animationData ? (
+        <section className="w-full max-w-5xl mx-auto px-6 pb-16">
+          <AnalysisResult data={animationData} fileSizeBytes={fileSizeBytes} />
+        </section>
+      ) : null}
 
       <section className="w-full max-w-5xl mx-auto px-6 py-16">
         <h2 className="text-3xl font-bold text-white text-center mb-12">

--- a/src/components/analysis/AnalysisResult.tsx
+++ b/src/components/analysis/AnalysisResult.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { analyzeLottie, type LottieJson } from "@/lib/lottie-analyzer";
+import { CompatibilitySection } from "./CompatibilitySection";
+import { LayersSection } from "./LayersSection";
+import { MetadataSection } from "./MetadataSection";
+import { OptimizationSection } from "./OptimizationSection";
+import { PerformanceSection } from "./PerformanceSection";
+
+interface AnalysisResultProps {
+  data: LottieJson;
+  fileSizeBytes: number | null;
+}
+
+export function AnalysisResult({ data, fileSizeBytes }: AnalysisResultProps) {
+  const [highlightedLayerIndex, setHighlightedLayerIndex] = useState<number | null>(
+    null,
+  );
+
+  const analysis = useMemo(
+    () => analyzeLottie(data, { fileSizeBytes }),
+    [data, fileSizeBytes],
+  );
+
+  const handleJumpToLayer = (layerIndex: number) => {
+    setHighlightedLayerIndex(layerIndex);
+    if (typeof window !== "undefined") {
+      const target = document.getElementById("analysis-layers");
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <MetadataSection metadata={analysis.metadata} />
+      <PerformanceSection score={analysis.performance} />
+      <OptimizationSection
+        suggestions={analysis.suggestions}
+        onJumpToLayer={handleJumpToLayer}
+      />
+      <LayersSection
+        data={analysis.layers}
+        highlightedLayerIndex={highlightedLayerIndex}
+        onClearHighlight={() => setHighlightedLayerIndex(null)}
+      />
+      <CompatibilitySection
+        compatibility={analysis.compatibility}
+        onJumpToLayer={handleJumpToLayer}
+      />
+    </div>
+  );
+}

--- a/src/components/analysis/CompatibilitySection.tsx
+++ b/src/components/analysis/CompatibilitySection.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import type {
+  PlatformCompatibility,
+  PlatformKey,
+  PlatformSupportLevel,
+} from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface CompatibilitySectionProps {
+  compatibility: PlatformCompatibility;
+  onJumpToLayer: (layerIndex: number) => void;
+}
+
+const PLATFORMS: PlatformKey[] = ["web", "ios", "android"];
+
+const LEVEL_STYLES: Record<
+  PlatformSupportLevel,
+  { icon: string; text: string; bg: string; ring: string }
+> = {
+  supported: {
+    icon: "✓",
+    text: "text-emerald-300",
+    bg: "bg-emerald-500/10",
+    ring: "ring-emerald-500/40",
+  },
+  partial: {
+    icon: "!",
+    text: "text-amber-300",
+    bg: "bg-amber-500/10",
+    ring: "ring-amber-500/40",
+  },
+  unsupported: {
+    icon: "✗",
+    text: "text-rose-300",
+    bg: "bg-rose-500/10",
+    ring: "ring-rose-500/40",
+  },
+};
+
+const AIRBNB_DOC_URL = "https://airbnb.io/lottie/#/supported-features";
+
+export function CompatibilitySection({
+  compatibility,
+  onJumpToLayer,
+}: CompatibilitySectionProps) {
+  const t = useTranslations("analysis.compatibility");
+  const [expanded, setExpanded] = useState<PlatformKey | null>(null);
+
+  const detected = compatibility.features.filter((f) => f.detectedInFile);
+
+  return (
+    <SectionCard
+      id="analysis-compatibility"
+      title={t("title")}
+      subtitle={t("subtitle")}
+      actions={
+        <a
+          href={AIRBNB_DOC_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-xs text-sky-300 hover:underline"
+        >
+          {t("officialDoc")}
+        </a>
+      }
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
+        {PLATFORMS.map((platform) => {
+          const summary = compatibility.summary[platform];
+          const style = LEVEL_STYLES[summary.overall];
+          const isOpen = expanded === platform;
+          return (
+            <button
+              key={platform}
+              type="button"
+              onClick={() => setExpanded(isOpen ? null : platform)}
+              className={`flex flex-col items-start rounded-lg p-4 text-left ring-1 ${style.bg} ${style.ring}`}
+              aria-expanded={isOpen}
+            >
+              <div className="flex w-full items-center justify-between">
+                <span className="text-sm font-semibold text-white">
+                  {t(`platforms.${platform}`)}
+                </span>
+                <span className={`text-2xl font-black ${style.text}`}>
+                  {style.icon}
+                </span>
+              </div>
+              <span className={`mt-2 text-xs ${style.text}`}>
+                {t(`levels.${summary.overall}`)}
+              </span>
+              <span className="mt-1 text-[11px] text-gray-400">
+                {t("issueBreakdown", {
+                  unsupported: summary.unsupportedCount,
+                  partial: summary.partialCount,
+                })}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {expanded ? (
+        <div className="mt-4 rounded-md border border-gray-700 bg-gray-900/40 p-4">
+          <h4 className="mb-2 text-sm font-semibold text-white">
+            {t("detectedIssues", { platform: t(`platforms.${expanded}`) })}
+          </h4>
+          {detected.length === 0 ? (
+            <p className="text-xs text-gray-400">{t("noIssues")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {detected
+                .filter((f) => f[expanded!] !== "supported")
+                .map((f) => {
+                  const level = f[expanded!];
+                  const style = LEVEL_STYLES[level];
+                  return (
+                    <li
+                      key={f.feature}
+                      className="flex flex-wrap items-center gap-3 rounded border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm"
+                    >
+                      <span className={`font-semibold ${style.text}`}>
+                        {style.icon}
+                      </span>
+                      <span className="text-gray-200">{f.feature}</span>
+                      <span className="ml-auto text-xs text-gray-400">
+                        {t(`levels.${level}`)}
+                      </span>
+                      {f.relatedLayerIndexes.length > 0 ? (
+                        <div className="flex w-full flex-wrap gap-1 pt-1">
+                          {f.relatedLayerIndexes.slice(0, 6).map((idx) => (
+                            <button
+                              key={idx}
+                              type="button"
+                              onClick={() => onJumpToLayer(idx)}
+                              className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[10px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
+                            >
+                              #{idx}
+                            </button>
+                          ))}
+                          {f.relatedLayerIndexes.length > 6 ? (
+                            <span className="text-[10px] text-gray-500">
+                              +{f.relatedLayerIndexes.length - 6}
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              {detected.filter((f) => f[expanded!] !== "supported").length ===
+              0 ? (
+                <p className="text-xs text-gray-400">{t("noIssues")}</p>
+              ) : null}
+            </ul>
+          )}
+        </div>
+      ) : null}
+
+      <div className="mt-5 overflow-hidden rounded-md border border-gray-800">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-gray-900/80 text-xs uppercase tracking-wide text-gray-400">
+            <tr>
+              <th className="px-3 py-2">{t("columnFeature")}</th>
+              {PLATFORMS.map((platform) => (
+                <th key={platform} className="px-3 py-2 text-center">
+                  {t(`platforms.${platform}`)}
+                </th>
+              ))}
+              <th className="px-3 py-2 text-center">{t("columnDetected")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {compatibility.features.map((f) => (
+              <tr
+                key={f.feature}
+                className="border-t border-gray-800 text-sm text-gray-200"
+              >
+                <td className="px-3 py-2">{f.feature}</td>
+                {PLATFORMS.map((platform) => {
+                  const level = f[platform];
+                  const style = LEVEL_STYLES[level];
+                  return (
+                    <td
+                      key={platform}
+                      className={`px-3 py-2 text-center font-semibold ${style.text}`}
+                    >
+                      {style.icon}
+                    </td>
+                  );
+                })}
+                <td className="px-3 py-2 text-center text-xs text-gray-400">
+                  {f.detectedInFile ? t("yes") : t("no")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/LayersSection.tsx
+++ b/src/components/analysis/LayersSection.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  getBlendModeName,
+  type AnalyzedLayer,
+  type LayerAnalysisResult,
+  type LayerTreeNode,
+} from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface LayersSectionProps {
+  data: LayerAnalysisResult;
+  highlightedLayerIndex: number | null;
+  onClearHighlight: () => void;
+}
+
+const TYPE_BADGE_CLASSES: Record<string, string> = {
+  Shape: "bg-emerald-500/20 text-emerald-300 border-emerald-500/40",
+  Image: "bg-sky-500/20 text-sky-300 border-sky-500/40",
+  Text: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+  Precomp: "bg-fuchsia-500/20 text-fuchsia-300 border-fuchsia-500/40",
+  Solid: "bg-rose-500/20 text-rose-300 border-rose-500/40",
+  Null: "bg-gray-500/20 text-gray-300 border-gray-500/40",
+  Audio: "bg-indigo-500/20 text-indigo-300 border-indigo-500/40",
+};
+
+function typeBadgeClass(typeName: string): string {
+  return (
+    TYPE_BADGE_CLASSES[typeName] ??
+    "bg-gray-700/60 text-gray-200 border-gray-600"
+  );
+}
+
+const PAGE_SIZE = 50;
+
+interface LayerRowProps {
+  layer: AnalyzedLayer;
+  highlighted: boolean;
+  registerRef: (idx: number, el: HTMLTableRowElement | null) => void;
+}
+
+function LayerRow({ layer, highlighted, registerRef }: LayerRowProps) {
+  return (
+    <tr
+      ref={(el) => registerRef(layer.index, el)}
+      className={`border-t border-gray-800 text-sm transition-colors ${
+        highlighted ? "bg-yellow-500/10" : "hover:bg-gray-800/40"
+      }`}
+    >
+      <td className="px-3 py-2 text-gray-400">{layer.index}</td>
+      <td className="px-3 py-2 text-white">
+        <div className="flex items-center gap-2">
+          <span>{layer.name}</span>
+          {layer.isHidden ? (
+            <span className="rounded bg-red-500/20 px-2 py-0.5 text-[10px] uppercase text-red-300">
+              hidden
+            </span>
+          ) : null}
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <span
+          className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium ${typeBadgeClass(
+            layer.typeName,
+          )}`}
+        >
+          {layer.typeName}
+        </span>
+      </td>
+      <td className="px-3 py-2 text-right font-mono text-xs text-gray-300">
+        {layer.startFrame} – {layer.endFrame}
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-300">
+        {getBlendModeName(layer.blendMode)}
+      </td>
+      <td className="px-3 py-2 text-center text-xs text-gray-300">
+        {layer.is3D ? "3D" : "—"}
+      </td>
+      <td className="px-3 py-2 text-right text-xs text-gray-300">
+        {layer.effectCount}
+      </td>
+      <td className="px-3 py-2 text-right text-xs text-gray-300">
+        {layer.maskCount}
+      </td>
+    </tr>
+  );
+}
+
+interface TreeNodeRowProps {
+  node: LayerTreeNode;
+  depth: number;
+  highlightedLayerIndex: number | null;
+}
+
+function TreeNodeRow({ node, depth, highlightedLayerIndex }: TreeNodeRowProps) {
+  const isHighlighted = highlightedLayerIndex === node.index;
+  return (
+    <li>
+      <div
+        className={`flex items-center gap-2 rounded px-2 py-1 text-sm ${
+          isHighlighted ? "bg-yellow-500/10 text-yellow-200" : "text-gray-200"
+        }`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        <span
+          className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${typeBadgeClass(
+            node.typeName,
+          )}`}
+        >
+          {node.typeName}
+        </span>
+        <span>{node.name}</span>
+        <span className="ml-auto font-mono text-[11px] text-gray-500">
+          #{node.index}
+        </span>
+      </div>
+      {node.children.length > 0 ? (
+        <ul>
+          {node.children.map((child) => (
+            <TreeNodeRow
+              key={child.index}
+              node={child}
+              depth={depth + 1}
+              highlightedLayerIndex={highlightedLayerIndex}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+export function LayersSection({
+  data,
+  highlightedLayerIndex,
+  onClearHighlight,
+}: LayersSectionProps) {
+  const t = useTranslations("analysis.layers");
+  const [mode, setMode] = useState<"list" | "tree">("list");
+  const [page, setPage] = useState(0);
+  const rowRefs = useRef(new Map<number, HTMLTableRowElement>());
+
+  const totalPages = Math.max(1, Math.ceil(data.layers.length / PAGE_SIZE));
+  const visibleLayers = useMemo(
+    () => data.layers.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [data.layers, page],
+  );
+
+  useEffect(() => {
+    if (highlightedLayerIndex === null) return;
+    if (mode !== "list") setMode("list");
+    const targetIdx = data.layers.findIndex(
+      (l) => l.index === highlightedLayerIndex,
+    );
+    if (targetIdx < 0) return;
+    const targetPage = Math.floor(targetIdx / PAGE_SIZE);
+    if (targetPage !== page) setPage(targetPage);
+  }, [highlightedLayerIndex, data.layers, mode, page]);
+
+  useEffect(() => {
+    if (highlightedLayerIndex === null) return;
+    const el = rowRefs.current.get(highlightedLayerIndex);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [highlightedLayerIndex, page, mode]);
+
+  const registerRef = (idx: number, el: HTMLTableRowElement | null) => {
+    if (el) rowRefs.current.set(idx, el);
+    else rowRefs.current.delete(idx);
+  };
+
+  return (
+    <SectionCard
+      id="analysis-layers"
+      title={t("title")}
+      subtitle={t("subtitle", { count: data.layers.length })}
+      actions={
+        <div className="flex gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5 text-xs">
+          <button
+            type="button"
+            onClick={() => setMode("list")}
+            className={`rounded px-2 py-1 ${
+              mode === "list"
+                ? "bg-gray-700 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t("listMode")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("tree")}
+            className={`rounded px-2 py-1 ${
+              mode === "tree"
+                ? "bg-gray-700 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t("treeMode")}
+          </button>
+        </div>
+      }
+    >
+      {data.layers.length === 0 ? (
+        <p className="text-sm text-gray-400">{t("empty")}</p>
+      ) : mode === "list" ? (
+        <>
+          <div className="max-h-[480px] overflow-auto rounded-md border border-gray-800">
+            <table className="min-w-full divide-y divide-gray-800 text-left">
+              <thead className="bg-gray-900/80 text-xs uppercase tracking-wide text-gray-400">
+                <tr>
+                  <th className="px-3 py-2">#</th>
+                  <th className="px-3 py-2">{t("columnName")}</th>
+                  <th className="px-3 py-2">{t("columnType")}</th>
+                  <th className="px-3 py-2 text-right">{t("columnFrames")}</th>
+                  <th className="px-3 py-2">{t("columnBlend")}</th>
+                  <th className="px-3 py-2 text-center">{t("column3D")}</th>
+                  <th className="px-3 py-2 text-right">{t("columnEffects")}</th>
+                  <th className="px-3 py-2 text-right">{t("columnMasks")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleLayers.map((layer) => (
+                  <LayerRow
+                    key={layer.index}
+                    layer={layer}
+                    highlighted={highlightedLayerIndex === layer.index}
+                    registerRef={registerRef}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 ? (
+            <div className="mt-3 flex items-center justify-between text-xs text-gray-400">
+              <span>
+                {t("pageStatus", {
+                  from: page * PAGE_SIZE + 1,
+                  to: Math.min((page + 1) * PAGE_SIZE, data.layers.length),
+                  total: data.layers.length,
+                })}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="rounded border border-gray-700 px-2 py-1 disabled:opacity-40"
+                >
+                  {t("prev")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setPage((p) => Math.min(totalPages - 1, p + 1))
+                  }
+                  disabled={page >= totalPages - 1}
+                  className="rounded border border-gray-700 px-2 py-1 disabled:opacity-40"
+                >
+                  {t("next")}
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <ul className="max-h-[480px] overflow-auto rounded-md border border-gray-800 bg-gray-900/40 p-2">
+          {data.tree.map((node) => (
+            <TreeNodeRow
+              key={node.index}
+              node={node}
+              depth={0}
+              highlightedLayerIndex={highlightedLayerIndex}
+            />
+          ))}
+        </ul>
+      )}
+
+      {highlightedLayerIndex !== null ? (
+        <button
+          type="button"
+          onClick={onClearHighlight}
+          className="mt-3 rounded border border-gray-700 px-3 py-1 text-xs text-gray-300 hover:bg-gray-800"
+        >
+          {t("clearHighlight")}
+        </button>
+      ) : null}
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/MetadataSection.tsx
+++ b/src/components/analysis/MetadataSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { formatDuration, formatFileSize } from "@/lib/lottie-analyzer";
+import type { LottieMetadata } from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface MetadataSectionProps {
+  metadata: LottieMetadata;
+}
+
+function MetricTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-md border border-gray-700 bg-gray-900/50 p-4">
+      <div className="text-xs uppercase tracking-wide text-gray-400">
+        {label}
+      </div>
+      <div className="mt-2 text-xl font-semibold text-white break-words">
+        {value}
+      </div>
+      {hint ? <div className="mt-1 text-xs text-gray-500">{hint}</div> : null}
+    </div>
+  );
+}
+
+export function MetadataSection({ metadata }: MetadataSectionProps) {
+  const t = useTranslations("analysis.metadata");
+  const layerTypes = ["Shape", "Image", "Text", "Precomp", "Solid", "Null"] as const;
+
+  const dimensions =
+    metadata.width && metadata.height
+      ? `${metadata.width} × ${metadata.height}`
+      : "—";
+
+  return (
+    <SectionCard id="analysis-metadata" title={t("title")} subtitle={t("subtitle")}>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <MetricTile
+          label={t("version")}
+          value={metadata.version ?? "—"}
+          hint={metadata.generator ?? undefined}
+        />
+        <MetricTile label={t("dimensions")} value={dimensions} />
+        <MetricTile
+          label={t("frameRate")}
+          value={metadata.frameRate ? `${metadata.frameRate} fps` : "—"}
+        />
+        <MetricTile
+          label={t("totalFrames")}
+          value={
+            metadata.totalFrames !== null ? String(metadata.totalFrames) : "—"
+          }
+          hint={
+            metadata.inPoint !== null && metadata.outPoint !== null
+              ? `${metadata.inPoint} → ${metadata.outPoint}`
+              : undefined
+          }
+        />
+        <MetricTile
+          label={t("duration")}
+          value={formatDuration(metadata.durationSeconds)}
+        />
+        <MetricTile label={t("layerCount")} value={String(metadata.layerCount)} />
+        <MetricTile
+          label={t("assetCount")}
+          value={String(metadata.assetCount)}
+          hint={t("assetBreakdown", {
+            images: metadata.imageAssetCount,
+            precomps: metadata.precompAssetCount,
+          })}
+        />
+        <MetricTile
+          label={t("embeddedImages")}
+          value={String(metadata.embeddedImageCount)}
+          hint={
+            metadata.imageAssetCount > 0
+              ? `${Math.round(
+                  (metadata.embeddedImageCount / metadata.imageAssetCount) * 100,
+                )}%`
+              : undefined
+          }
+        />
+        <MetricTile label={t("markers")} value={String(metadata.markerCount)} />
+        <MetricTile
+          label={t("fileSize")}
+          value={formatFileSize(metadata.fileSizeBytes)}
+        />
+        <MetricTile
+          label={t("is3D")}
+          value={metadata.is3D ? t("yes") : t("no")}
+        />
+      </div>
+
+      <div className="mt-6">
+        <h4 className="mb-2 text-sm font-semibold text-gray-300">
+          {t("layerTypesHeading")}
+        </h4>
+        <div className="flex flex-wrap gap-2">
+          {layerTypes.map((type) => (
+            <span
+              key={type}
+              className="inline-flex items-center gap-1 rounded-full border border-gray-700 bg-gray-900/60 px-3 py-1 text-xs text-gray-300"
+            >
+              <span className="font-medium">{type}</span>
+              <span className="text-gray-500">·</span>
+              <span className="text-white">
+                {metadata.layerCountsByType[type] ?? 0}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/OptimizationSection.tsx
+++ b/src/components/analysis/OptimizationSection.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type {
+  OptimizationSuggestion,
+  SuggestionCode,
+  SuggestionSeverity,
+} from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface OptimizationSectionProps {
+  suggestions: OptimizationSuggestion[];
+  onJumpToLayer: (layerIndex: number) => void;
+}
+
+const SEVERITY_STYLES: Record<SuggestionSeverity, { border: string; dot: string; label: string }> = {
+  info: {
+    border: "border-sky-500/40",
+    dot: "bg-sky-400",
+    label: "bg-sky-500/20 text-sky-200 border-sky-500/40",
+  },
+  warning: {
+    border: "border-amber-500/40",
+    dot: "bg-amber-400",
+    label: "bg-amber-500/20 text-amber-200 border-amber-500/40",
+  },
+  error: {
+    border: "border-rose-500/40",
+    dot: "bg-rose-400",
+    label: "bg-rose-500/20 text-rose-200 border-rose-500/40",
+  },
+};
+
+const CODE_I18N_KEYS: Record<SuggestionCode, string> = {
+  EMBEDDED_IMAGES: "embeddedImages",
+  UNNAMED_LAYERS: "unnamedLayers",
+  EXPRESSIONS: "expressions",
+  HIDDEN_LAYERS: "hiddenLayers",
+  DUPLICATE_SHAPE_PATHS: "duplicateShapePaths",
+  EXCESSIVE_KEYFRAMES: "excessiveKeyframes",
+  LARGE_IMAGE_RESIZE: "largeImageResize",
+  MISSING_MARKERS: "missingMarkers",
+};
+
+export function OptimizationSection({
+  suggestions,
+  onJumpToLayer,
+}: OptimizationSectionProps) {
+  const t = useTranslations("analysis.optimization");
+  const severityRank = { error: 0, warning: 1, info: 2 } as const;
+  const sorted = [...suggestions].sort(
+    (a, b) => severityRank[a.severity] - severityRank[b.severity],
+  );
+
+  return (
+    <SectionCard
+      id="analysis-optimization"
+      title={t("title")}
+      subtitle={t("subtitle", { count: suggestions.length })}
+    >
+      {sorted.length === 0 ? (
+        <p className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+          {t("allClear")}
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {sorted.map((s, idx) => {
+            const style = SEVERITY_STYLES[s.severity];
+            const key = CODE_I18N_KEYS[s.code];
+            return (
+              <li
+                key={`${s.code}-${idx}`}
+                className={`rounded-md border bg-gray-900/50 p-4 ${style.border}`}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${style.dot}`}
+                    aria-hidden
+                  />
+                  <h4 className="text-sm font-semibold text-white">
+                    {t(`codes.${key}.title`)}
+                  </h4>
+                  <span
+                    className={`ml-auto inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${style.label}`}
+                  >
+                    {t(`severity.${s.severity}`)}
+                  </span>
+                  {s.metric !== undefined ? (
+                    <span className="rounded-full border border-gray-700 px-2 py-0.5 text-[10px] text-gray-300">
+                      {t(`codes.${key}.metric`, { value: s.metric })}
+                    </span>
+                  ) : null}
+                </div>
+
+                <dl className="mt-3 space-y-2 text-sm">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-gray-500">
+                      {t("what")}
+                    </dt>
+                    <dd className="text-gray-200">
+                      {t(`codes.${key}.what`)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-gray-500">
+                      {t("why")}
+                    </dt>
+                    <dd className="text-gray-300">
+                      {t(`codes.${key}.why`)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-gray-500">
+                      {t("how")}
+                    </dt>
+                    <dd className="text-gray-300">
+                      {t(`codes.${key}.how`)}
+                    </dd>
+                  </div>
+                </dl>
+
+                {s.relatedLayerIndexes.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <span className="text-[11px] uppercase text-gray-500">
+                      {t("relatedLayers")}
+                    </span>
+                    {s.relatedLayerIndexes.slice(0, 8).map((idx) => (
+                      <button
+                        key={idx}
+                        type="button"
+                        onClick={() => onJumpToLayer(idx)}
+                        className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[11px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
+                      >
+                        #{idx}
+                      </button>
+                    ))}
+                    {s.relatedLayerIndexes.length > 8 ? (
+                      <span className="text-[11px] text-gray-500">
+                        +{s.relatedLayerIndexes.length - 8}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/PerformanceSection.tsx
+++ b/src/components/analysis/PerformanceSection.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { PerformanceGrade, PerformanceScore } from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface PerformanceSectionProps {
+  score: PerformanceScore;
+}
+
+const GRADE_COLORS: Record<PerformanceGrade, { ring: string; text: string; bg: string }> = {
+  A: { ring: "ring-emerald-500", text: "text-emerald-300", bg: "bg-emerald-500/10" },
+  B: { ring: "ring-lime-500", text: "text-lime-300", bg: "bg-lime-500/10" },
+  C: { ring: "ring-amber-500", text: "text-amber-300", bg: "bg-amber-500/10" },
+  D: { ring: "ring-orange-500", text: "text-orange-300", bg: "bg-orange-500/10" },
+  F: { ring: "ring-rose-500", text: "text-rose-300", bg: "bg-rose-500/10" },
+};
+
+export function PerformanceSection({ score }: PerformanceSectionProps) {
+  const t = useTranslations("analysis.performance");
+  const colors = GRADE_COLORS[score.grade];
+  const sortedBreakdown = [...score.breakdown].sort(
+    (a, b) => a.contribution - b.contribution,
+  );
+
+  return (
+    <SectionCard
+      id="analysis-performance"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="grid gap-6 md:grid-cols-[200px_1fr]">
+        <div
+          className={`flex flex-col items-center justify-center rounded-xl p-6 ${colors.bg} ring-2 ${colors.ring}`}
+        >
+          <span className={`text-6xl font-black ${colors.text}`}>
+            {score.grade}
+          </span>
+          <span className="mt-2 text-3xl font-bold text-white">
+            {score.score}
+          </span>
+          <span className="mt-1 text-xs uppercase tracking-widest text-gray-400">
+            /100
+          </span>
+        </div>
+
+        <div>
+          <h4 className="mb-3 text-sm font-semibold text-gray-300">
+            {t("breakdownHeading")}
+          </h4>
+          <ul className="space-y-2">
+            {sortedBreakdown.map((metric) => {
+              const contributionPct = (metric.contribution / 100) * 100;
+              return (
+                <li key={metric.key}>
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-gray-300">
+                      {t(`metric.${metric.key}`)}
+                    </span>
+                    <span className="font-mono text-gray-400">
+                      {metric.score}/100 × {Math.round(metric.weight * 100)}% ={" "}
+                      <span className="text-white">
+                        {metric.contribution.toFixed(1)}
+                      </span>
+                    </span>
+                  </div>
+                  <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-gray-800">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-sky-500 to-emerald-500"
+                      style={{ width: `${contributionPct}%` }}
+                    />
+                  </div>
+                  <div className="mt-1 text-[10px] text-gray-500">
+                    {t("rawValue", { value: metric.rawValue })}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/SectionCard.tsx
+++ b/src/components/analysis/SectionCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+interface SectionCardProps {
+  id: string;
+  title: string;
+  subtitle?: string;
+  defaultOpen?: boolean;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export function SectionCard({
+  id,
+  title,
+  subtitle,
+  defaultOpen = true,
+  actions,
+  children,
+}: SectionCardProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const contentId = `${id}-content`;
+
+  return (
+    <section
+      id={id}
+      className="w-full rounded-lg border border-gray-700 bg-gray-800/60 shadow-sm"
+    >
+      <header className="flex items-center justify-between gap-3 px-5 py-4">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex flex-1 items-center justify-between text-left text-white"
+          aria-expanded={open}
+          aria-controls={contentId}
+        >
+          <div>
+            <h3 className="text-lg font-semibold">{title}</h3>
+            {subtitle ? (
+              <p className="mt-1 text-sm text-gray-400">{subtitle}</p>
+            ) : null}
+          </div>
+          <span
+            aria-hidden
+            className={`ml-4 inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-600 text-gray-300 transition-transform ${
+              open ? "rotate-90" : ""
+            }`}
+          >
+            ›
+          </span>
+        </button>
+        {actions ? <div className="flex-shrink-0">{actions}</div> : null}
+      </header>
+      {open ? (
+        <div id={contentId} className="border-t border-gray-700 px-5 py-5">
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## 📌 Summary

> JSO-1의 Phase B로, Phase A에서 만든 `analyzeLottie()` 결과를 업로드 결과 화면에 Section 1~5 collapsible UI로 자동 렌더링한다.

## 📋 Changes

- `./src/components/analysis/SectionCard.tsx`: collapsible 섹션 래퍼
- `./src/components/analysis/MetadataSection.tsx`: 스펙/차원/프레임/재생시간/레이어 수/에셋/임베디드 이미지/마커/파일 크기/3D 여부 타일 + 타입별 배지
- `./src/components/analysis/LayersSection.tsx`: 리스트/트리 토글, 타입별 컬러 배지, hidden flag, 이펙트/마스크 수 컬럼, 50개 페이지네이션(가상화 대체), 외부에서 전달된 highlight index를 따라 해당 페이지로 점프 + `scrollIntoView`
- `./src/components/analysis/PerformanceSection.tsx`: 등급별 색상 링 A~F 원형 배지, 메트릭별 기여도 bar (가중치 × score)
- `./src/components/analysis/OptimizationSection.tsx`: 8개 규칙 (embeddedImages/unnamedLayers/expressions/hiddenLayers/duplicateShapePaths/excessiveKeyframes/largeImageResize/missingMarkers), severity 컬러, what/why/how 블록, 관련 레이어로 이동하는 `#{idx}` 버튼
- `./src/components/analysis/CompatibilitySection.tsx`: 플랫폼 요약 카드(✅/⚠️/❌ + 미지원/부분 수 표기), 클릭 시 상세 이슈 리스트, 전체 feature 매트릭스 테이블, Airbnb 공식 문서 링크
- `./src/components/analysis/AnalysisResult.tsx`: `useMemo`로 `analyzeLottie` 실행, highlight 레이어 index를 섹션 간 공유, Optimization/Compatibility에서 점프 요청 시 Section 2로 스크롤
- `./src/app/[locale]/page.tsx`: 업로드된 `LottieJson`과 `file.size`를 `AnalysisResult`에 전달, 기존 `AnimationData` 커스텀 인터페이스 제거하고 `LottieJson`으로 통일
- `./messages/en.json`, `./messages/ko.json`: `analysis.*` namespace 추가 (metadata/layers/performance/optimization/compatibility)

## 🧠 Context & Background

Phase A에서 순수 로직 계층이 완성되었으므로 이번 Phase B에서 업로드 즉시 "유틸리티 + 콘텐츠" 전환의 핵심인 결과 화면을 구성한다. Section 6~8(재생 컨트롤/배경/스니펫)과 최종 i18n/다크모드/반응형 다듬기는 Phase C/D에서 이어진다.

## ✅ How to Test

1. `npm install`
2. `npm test` → vitest 30/30 통과 (유틸 로직)
3. `npx tsc --noEmit` 타입 에러 없음
4. `npm run lint` ESLint 경고/에러 없음
5. `npm run build` 프로덕션 빌드 성공
6. `npm run dev` → `http://localhost:3000` 접속 → Lottie JSON 드래그 앤 드롭 → 뷰어 아래 5개 섹션(메타데이터 / 성능 점수 / 최적화 제안 / 레이어 / 호환성) 자동 렌더링 확인
7. 최적화 제안 또는 호환성 섹션에서 `#{idx}` 버튼 클릭 시 레이어 섹션으로 스크롤 + 해당 행 하이라이트 + 페이지 자동 전환 동작 확인

## 🔗 Related Issues

- Related: JSO-1 (Phase B / 4단계 분할 중 2단계)

## 🙌 Additional Notes

- Phase A의 `optimization.ts`가 반환하는 `what/why/how` 키 문자열이 이번 PR의 `messages/*.json` `analysis.optimization.codes.*`에 연결되었다.
- 레이어 가상화는 이슈 요구사항의 "100+ 레이어 케이스 가상화"를 페이지네이션(50/page)으로 대체했다. react-window 의존성을 피하기 위한 선택이며, 수천 개 레이어 edge case가 실제 발생하면 Phase C/D에서 재검토 가능.
- 다크/라이트 모드 대응과 반응형 세부 튜닝은 Phase D 범위다. 현재는 기존 페이지와 같은 dark palette만 쓴다.