### PR TITLE
feature/JSO-1-phase-c-sections-6-8

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -145,6 +145,64 @@
       "columnDetected": "In file",
       "yes": "Yes",
       "no": "No"
+    },
+    "playerControls": {
+      "title": "Playback Controls",
+      "subtitle": "Speed, direction, loop mode and frame scrubbing",
+      "play": "Play",
+      "pause": "Pause",
+      "directionToggle": "Toggle direction",
+      "forward": "Forward →",
+      "backward": "← Reverse",
+      "loopMode": {
+        "loop": "Loop",
+        "once": "Once",
+        "pingpong": "Ping-pong"
+      },
+      "frame": "Frame",
+      "scrub": "Scrub frame",
+      "segmentLegend": "Loop a segment",
+      "segmentEnable": "Enable segment loop",
+      "from": "From",
+      "to": "To",
+      "shortcutsHelp": "Shortcuts — Space: play/pause, ←/→: step 1 frame, Shift+←/→: step 10 frames"
+    },
+    "background": {
+      "title": "Background",
+      "subtitle": "Check your animation against different canvases",
+      "presetsHeading": "Presets",
+      "presets": {
+        "transparent": "Transparent",
+        "white": "White",
+        "black": "Black",
+        "lightTone1": "Light 1",
+        "lightTone2": "Light 2",
+        "darkTone1": "Dark 1",
+        "darkTone2": "Dark 2"
+      },
+      "customColorHeading": "Custom color",
+      "customColorPicker": "Color picker",
+      "customColorHex": "Hex color",
+      "applyColor": "Apply",
+      "recentColors": "Recently used",
+      "customImageHeading": "Custom image",
+      "customImageNote": "Images are loaded locally with blob URLs — nothing is uploaded.",
+      "customImageUpload": "Upload background image"
+    },
+    "snippets": {
+      "title": "Code Snippets",
+      "subtitle": "Drop-in code for the most common Lottie runtimes",
+      "platforms": {
+        "react": "React",
+        "next": "Next.js",
+        "vue": "Vue 3",
+        "html": "HTML",
+        "swift": "Swift (iOS)",
+        "kotlin": "Kotlin (Android)"
+      },
+      "copy": "Copy",
+      "copied": "Copied!",
+      "reflectedContext": "Generated for {file} ({width} × {height})"
     }
   },
   "common": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -145,6 +145,64 @@
       "columnDetected": "파일 내 사용",
       "yes": "예",
       "no": "아니오"
+    },
+    "playerControls": {
+      "title": "재생 컨트롤",
+      "subtitle": "속도, 방향, 반복 모드와 프레임 스크러빙",
+      "play": "재생",
+      "pause": "일시정지",
+      "directionToggle": "방향 전환",
+      "forward": "정방향 →",
+      "backward": "← 역방향",
+      "loopMode": {
+        "loop": "반복",
+        "once": "한 번",
+        "pingpong": "왕복"
+      },
+      "frame": "프레임",
+      "scrub": "프레임 스크럽",
+      "segmentLegend": "구간 반복",
+      "segmentEnable": "구간 반복 활성화",
+      "from": "시작",
+      "to": "종료",
+      "shortcutsHelp": "단축키 — Space: 재생/일시정지, ←/→: 1프레임 이동, Shift+←/→: 10프레임 이동"
+    },
+    "background": {
+      "title": "배경 변경",
+      "subtitle": "다양한 배경에서 애니메이션이 어떻게 보이는지 확인하세요",
+      "presetsHeading": "프리셋",
+      "presets": {
+        "transparent": "투명",
+        "white": "흰색",
+        "black": "검정",
+        "lightTone1": "라이트 1",
+        "lightTone2": "라이트 2",
+        "darkTone1": "다크 1",
+        "darkTone2": "다크 2"
+      },
+      "customColorHeading": "커스텀 색상",
+      "customColorPicker": "색상 피커",
+      "customColorHex": "HEX 색상",
+      "applyColor": "적용",
+      "recentColors": "최근 사용",
+      "customImageHeading": "커스텀 이미지",
+      "customImageNote": "이미지는 로컬 blob URL로만 처리되며 외부로 업로드되지 않습니다.",
+      "customImageUpload": "배경 이미지 업로드"
+    },
+    "snippets": {
+      "title": "코드 스니펫",
+      "subtitle": "주요 Lottie 런타임별 즉시 사용 가능한 코드",
+      "platforms": {
+        "react": "React",
+        "next": "Next.js",
+        "vue": "Vue 3",
+        "html": "HTML",
+        "swift": "Swift (iOS)",
+        "kotlin": "Kotlin (Android)"
+      },
+      "copy": "복사",
+      "copied": "복사 완료!",
+      "reflectedContext": "{file} ({width} × {height})용 스니펫"
     }
   },
   "common": {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,72 +1,31 @@
 "use client";
 
-import { useState, useEffect, useRef, Suspense } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
-import type { AnimationItem, LottiePlayer } from "lottie-web";
+import type { LottiePlayer } from "lottie-web";
 import { AnalysisResult } from "@/components/analysis/AnalysisResult";
+import { BackgroundSection } from "@/components/player/BackgroundSection";
+import {
+  LottiePlayerStage,
+  type LottiePlayerHandle,
+} from "@/components/player/LottiePlayerStage";
+import { PlayerControlsSection } from "@/components/player/PlayerControlsSection";
+import type { PlayerState } from "@/components/player/types";
 import type { LottieJson } from "@/lib/lottie-analyzer";
 
-type AnimationData = LottieJson;
-
-function LoadingFallback() {
-  const t = useTranslations("common");
-  return (
-    <div className="flex items-center justify-center w-full h-96 bg-gray-800 rounded-lg">
-      <div className="animate-pulse text-gray-400">{t("loading")}</div>
-    </div>
-  );
-}
-
-function AnimationContainer({
-  lottie,
-  animationData,
-  containerRef,
-  setAnimationSize,
-}: {
-  lottie: LottiePlayer | null;
-  animationData: AnimationData | null;
-  containerRef: React.RefObject<HTMLDivElement>;
-  setAnimationSize: (size: { width: number; height: number }) => void;
-}) {
-  const animationRef = useRef<AnimationItem | null>(null);
-
-  useEffect(() => {
-    if (lottie && animationData && containerRef.current) {
-      if (animationRef.current) {
-        animationRef.current.destroy();
-      }
-
-      containerRef.current.innerHTML = "";
-      animationRef.current = lottie.loadAnimation({
-        container: containerRef.current,
-        renderer: "svg",
-        loop: true,
-        autoplay: true,
-        animationData,
-      });
-
-      if (animationData.w && animationData.h) {
-        setAnimationSize({ width: animationData.w, height: animationData.h });
-      }
-
-      return () => {
-        if (animationRef.current) {
-          animationRef.current.destroy();
-        }
-      };
-    }
-  }, [lottie, animationData, containerRef, setAnimationSize]);
-
-  return null;
-}
+const DEFAULT_PLAYER_STATE: PlayerState = {
+  speed: 1,
+  direction: 1,
+  loopMode: "loop",
+  segment: null,
+  background: { kind: "transparent" },
+};
 
 export default function Home() {
   const t = useTranslations("home");
   const [lottie, setLottie] = useState<LottiePlayer | null>(null);
-  const [animationData, setAnimationData] = useState<AnimationData | null>(
-    null
-  );
+  const [animationData, setAnimationData] = useState<LottieJson | null>(null);
   const [animationSize, setAnimationSize] = useState<{
     width: number;
     height: number;
@@ -74,8 +33,16 @@ export default function Home() {
 
   const [fileName, setFileName] = useState<string | null>(null);
   const [fileSizeBytes, setFileSizeBytes] = useState<number | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [playerState, setPlayerState] =
+    useState<PlayerState>(DEFAULT_PLAYER_STATE);
+  const [currentFrame, setCurrentFrame] = useState(0);
+  const [totalFrames, setTotalFrames] = useState(0);
+  const [frameRate, setFrameRate] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const playerHandleRef = useRef<LottiePlayerHandle | null>(null);
+  const dropZoneRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const loadLottie = async () => {
@@ -88,16 +55,13 @@ export default function Home() {
     };
 
     loadLottie();
-
-    const updateViewportSize = () => {};
-
-    updateViewportSize();
-    window.addEventListener("resize", updateViewportSize);
-
-    return () => {
-      window.removeEventListener("resize", updateViewportSize);
-    };
   }, []);
+
+  useEffect(() => {
+    if (animationData?.w && animationData?.h) {
+      setAnimationSize({ width: animationData.w, height: animationData.h });
+    }
+  }, [animationData]);
 
   const loadFile = (file: File) => {
     const reader = new FileReader();
@@ -105,10 +69,12 @@ export default function Home() {
       try {
         const result = e.target?.result as string;
         if (result) {
-          const parsedData = JSON.parse(result) as AnimationData;
+          const parsedData = JSON.parse(result) as LottieJson;
           setAnimationData(parsedData);
           setFileName(file.name);
           setFileSizeBytes(file.size);
+          setPlayerState(DEFAULT_PLAYER_STATE);
+          setCurrentFrame(0);
         }
       } catch (error) {
         console.error("Invalid JSON file", error);
@@ -138,6 +104,10 @@ export default function Home() {
     }
   };
 
+  const updatePlayerState = (partial: Partial<PlayerState>) => {
+    setPlayerState((prev) => ({ ...prev, ...partial }));
+  };
+
   return (
     <div className="flex flex-col items-center bg-gray-900">
       <section className="flex flex-col items-center justify-center min-h-screen p-6 w-full">
@@ -150,7 +120,7 @@ export default function Home() {
         <p className="text-[12px] md:text-[14px] lg:text-[16px] text-gray-400 mb-6 text-center">
           {t("privacyNote")}
         </p>
-      <label className="mb-4 w-fit text-center">
+        <label className="mb-4 w-fit text-center">
           {fileName && (
             <span className="mt-2 mr-2 text-gray-200">{fileName}</span>
           )}
@@ -170,28 +140,35 @@ export default function Home() {
             <span className="absolute inset-0 w-full h-full border-2 border-transparent rounded-lg animate-pulse"></span>
           </button>
         </label>
-        <div
-          ref={containerRef}
-          className="border border-gray-700 w-full max-w-md h-96 flex items-center justify-center mb-8 bg-gray-800 rounded-lg shadow-lg"
-          onDrop={handleDrop}
-          onDragOver={handleDragOver}
-          aria-label={t("dropHere")}
-          role="region"
-        >
-          {!animationData && (
+
+        {!animationData ? (
+          <div
+            ref={dropZoneRef}
+            className="border border-gray-700 w-full max-w-md h-96 flex items-center justify-center mb-8 bg-gray-800 rounded-lg shadow-lg"
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            aria-label={t("dropHere")}
+            role="region"
+          >
             <p className="text-gray-400">{t("dropHere")}</p>
-          )}
-        </div>
-        {lottie && animationData && (
-          <Suspense fallback={<LoadingFallback />}>
-            <AnimationContainer
+          </div>
+        ) : lottie ? (
+          <div className="w-full max-w-md">
+            <LottiePlayerStage
               lottie={lottie}
-              animationData={animationData}
-              containerRef={containerRef as React.RefObject<HTMLDivElement>}
-              setAnimationSize={setAnimationSize}
+              data={animationData}
+              state={playerState}
+              onFrame={setCurrentFrame}
+              onReady={(total, fr) => {
+                setTotalFrames(total);
+                setFrameRate(fr);
+              }}
+              onPlayStateChange={setIsPlaying}
+              handleRef={playerHandleRef}
             />
-          </Suspense>
-        )}
+          </div>
+        ) : null}
+
         <div className="mt-4">
           <p className="animation-size text-gray-300">
             {t("animationSize")} {animationSize.width} x{" "}
@@ -200,9 +177,30 @@ export default function Home() {
         </div>
       </section>
 
-      {animationData ? (
+      {animationData && fileName ? (
         <section className="w-full max-w-5xl mx-auto px-6 pb-16">
-          <AnalysisResult data={animationData} fileSizeBytes={fileSizeBytes} />
+          <div className="flex flex-col gap-4">
+            <PlayerControlsSection
+              state={playerState}
+              onChange={updatePlayerState}
+              playerHandle={playerHandleRef}
+              currentFrame={currentFrame}
+              totalFrames={totalFrames}
+              frameRate={frameRate}
+              isPlaying={isPlaying}
+            />
+            <BackgroundSection
+              value={playerState.background}
+              onChange={(background) => updatePlayerState({ background })}
+            />
+          </div>
+          <div className="mt-4">
+            <AnalysisResult
+              data={animationData}
+              fileSizeBytes={fileSizeBytes}
+              fileName={fileName}
+            />
+          </div>
         </section>
       ) : null}
 

--- a/src/components/analysis/AnalysisResult.tsx
+++ b/src/components/analysis/AnalysisResult.tsx
@@ -7,13 +7,15 @@ import { LayersSection } from "./LayersSection";
 import { MetadataSection } from "./MetadataSection";
 import { OptimizationSection } from "./OptimizationSection";
 import { PerformanceSection } from "./PerformanceSection";
+import { SnippetSection } from "./SnippetSection";
 
 interface AnalysisResultProps {
   data: LottieJson;
   fileSizeBytes: number | null;
+  fileName: string;
 }
 
-export function AnalysisResult({ data, fileSizeBytes }: AnalysisResultProps) {
+export function AnalysisResult({ data, fileSizeBytes, fileName }: AnalysisResultProps) {
   const [highlightedLayerIndex, setHighlightedLayerIndex] = useState<number | null>(
     null,
   );
@@ -49,6 +51,11 @@ export function AnalysisResult({ data, fileSizeBytes }: AnalysisResultProps) {
       <CompatibilitySection
         compatibility={analysis.compatibility}
         onJumpToLayer={handleJumpToLayer}
+      />
+      <SnippetSection
+        fileName={fileName}
+        width={analysis.metadata.width}
+        height={analysis.metadata.height}
       />
     </div>
   );

--- a/src/components/analysis/SnippetSection.tsx
+++ b/src/components/analysis/SnippetSection.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { generateSnippet, type SnippetPlatform } from "@/lib/snippets/generate";
+import { SectionCard } from "./SectionCard";
+
+interface SnippetSectionProps {
+  fileName: string;
+  width: number | null;
+  height: number | null;
+}
+
+const PLATFORMS: SnippetPlatform[] = [
+  "react",
+  "next",
+  "vue",
+  "html",
+  "swift",
+  "kotlin",
+];
+
+function highlight(code: string, language: string): React.ReactNode {
+  const keywordPatterns: Record<string, RegExp> = {
+    tsx: /\b(import|from|export|function|const|let|var|return|async|await|dynamic|default|as|style|true|false|null)\b/g,
+    vue: /\b(script|setup|lang|import|from|template)\b/g,
+    html: /\b(src|background|speed|style|loop|autoplay|script)\b/g,
+    swift: /\b(import|class|final|override|func|let|var|return|true|false|super|init)\b/g,
+    kotlin: /\b(import|val|var|implementation|fun|class)\b/g,
+  };
+  const pattern = keywordPatterns[language];
+  if (!pattern) return code;
+  const parts: (string | { kw: string; idx: number })[] = [];
+  let lastIndex = 0;
+  const globalPattern = new RegExp(pattern.source, "g");
+  let match;
+  let counter = 0;
+  while ((match = globalPattern.exec(code)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(code.slice(lastIndex, match.index));
+    }
+    parts.push({ kw: match[0], idx: counter++ });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < code.length) parts.push(code.slice(lastIndex));
+
+  return parts.map((part, i) =>
+    typeof part === "string" ? (
+      <span key={`t-${i}`}>{part}</span>
+    ) : (
+      <span key={`k-${part.idx}`} className="text-sky-300">
+        {part.kw}
+      </span>
+    ),
+  );
+}
+
+export function SnippetSection({ fileName, width, height }: SnippetSectionProps) {
+  const t = useTranslations("analysis.snippets");
+  const [platform, setPlatform] = useState<SnippetPlatform>("react");
+  const [copied, setCopied] = useState(false);
+
+  const snippet = useMemo(
+    () => generateSnippet(platform, { fileName, width, height }),
+    [platform, fileName, width, height],
+  );
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet.code);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <SectionCard
+      id="analysis-snippets"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="mb-4 flex flex-wrap gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5">
+        {PLATFORMS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPlatform(p)}
+            className={`rounded px-3 py-1 text-xs ${
+              platform === p
+                ? "bg-gray-700 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t(`platforms.${p}`)}
+          </button>
+        ))}
+      </div>
+
+      {snippet.install ? (
+        <div className="mb-2 rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2 font-mono text-xs text-gray-300">
+          <span className="mr-2 text-gray-500">$</span>
+          <span className="whitespace-pre">{snippet.install}</span>
+        </div>
+      ) : null}
+
+      <div className="relative">
+        <pre className="max-h-[420px] overflow-auto rounded-md border border-gray-800 bg-gray-950/80 p-4 font-mono text-xs leading-relaxed text-gray-200">
+          <code>{highlight(snippet.code, snippet.language)}</code>
+        </pre>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="absolute right-3 top-3 rounded border border-gray-700 bg-gray-900/80 px-2 py-1 text-[11px] text-gray-200 hover:bg-gray-800"
+        >
+          {copied ? t("copied") : t("copy")}
+        </button>
+      </div>
+
+      <p className="mt-3 text-[11px] text-gray-500">
+        {t("reflectedContext", {
+          file: fileName,
+          width: width ?? "—",
+          height: height ?? "—",
+        })}
+      </p>
+    </SectionCard>
+  );
+}

--- a/src/components/player/BackgroundSection.tsx
+++ b/src/components/player/BackgroundSection.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { SectionCard } from "@/components/analysis/SectionCard";
+import type { BackgroundValue } from "./types";
+
+interface BackgroundSectionProps {
+  value: BackgroundValue;
+  onChange: (value: BackgroundValue) => void;
+}
+
+interface Preset {
+  id: string;
+  labelKey: string;
+  value: BackgroundValue;
+  previewStyle: React.CSSProperties;
+}
+
+const PRESETS: Preset[] = [
+  {
+    id: "transparent",
+    labelKey: "transparent",
+    value: { kind: "transparent" },
+    previewStyle: {
+      backgroundImage:
+        "linear-gradient(45deg, #bbb 25%, transparent 25%), linear-gradient(-45deg, #bbb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #bbb 75%), linear-gradient(-45deg, transparent 75%, #bbb 75%)",
+      backgroundSize: "10px 10px",
+      backgroundPosition: "0 0, 0 5px, 5px -5px, -5px 0",
+      backgroundColor: "#eee",
+    },
+  },
+  {
+    id: "white",
+    labelKey: "white",
+    value: { kind: "color", color: "#ffffff" },
+    previewStyle: { backgroundColor: "#ffffff" },
+  },
+  {
+    id: "black",
+    labelKey: "black",
+    value: { kind: "color", color: "#000000" },
+    previewStyle: { backgroundColor: "#000000" },
+  },
+  {
+    id: "lightTone1",
+    labelKey: "lightTone1",
+    value: { kind: "color", color: "#f5f5f4" },
+    previewStyle: { backgroundColor: "#f5f5f4" },
+  },
+  {
+    id: "lightTone2",
+    labelKey: "lightTone2",
+    value: { kind: "color", color: "#e0f2fe" },
+    previewStyle: { backgroundColor: "#e0f2fe" },
+  },
+  {
+    id: "darkTone1",
+    labelKey: "darkTone1",
+    value: { kind: "color", color: "#0f172a" },
+    previewStyle: { backgroundColor: "#0f172a" },
+  },
+  {
+    id: "darkTone2",
+    labelKey: "darkTone2",
+    value: { kind: "color", color: "#1f2937" },
+    previewStyle: { backgroundColor: "#1f2937" },
+  },
+];
+
+const RECENT_STORAGE_KEY = "lottieViewer.recentBgColors";
+const MAX_RECENT = 6;
+
+function isValidHex(v: string): boolean {
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(v);
+}
+
+function readRecent(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string" && isValidHex(v));
+  } catch {
+    return [];
+  }
+}
+
+function writeRecent(next: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // localStorage may be unavailable (private mode)
+  }
+}
+
+export function BackgroundSection({ value, onChange }: BackgroundSectionProps) {
+  const t = useTranslations("analysis.background");
+  const [customColor, setCustomColor] = useState<string>(
+    value.kind === "color" ? (value.color ?? "#111111") : "#111111",
+  );
+  const [recent, setRecent] = useState<string[]>([]);
+  const imageUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setRecent(readRecent());
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (imageUrlRef.current) {
+        URL.revokeObjectURL(imageUrlRef.current);
+        imageUrlRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const applyColor = (color: string) => {
+    if (!isValidHex(color)) return;
+    onChange({ kind: "color", color });
+    setRecent((prev) => {
+      const next = [color, ...prev.filter((c) => c.toLowerCase() !== color.toLowerCase())].slice(
+        0,
+        MAX_RECENT,
+      );
+      writeRecent(next);
+      return next;
+    });
+  };
+
+  const handleImage = (file: File) => {
+    const url = URL.createObjectURL(file);
+    if (imageUrlRef.current) {
+      URL.revokeObjectURL(imageUrlRef.current);
+    }
+    imageUrlRef.current = url;
+    onChange({ kind: "image", imageUrl: url });
+  };
+
+  const activePresetId =
+    value.kind === "transparent"
+      ? "transparent"
+      : value.kind === "color"
+        ? PRESETS.find(
+            (p) => p.value.kind === "color" && p.value.color === value.color,
+          )?.id ?? null
+        : null;
+
+  return (
+    <SectionCard
+      id="analysis-background"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="space-y-5">
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("presetsHeading")}
+          </h4>
+          <div className="flex flex-wrap gap-2">
+            {PRESETS.map((preset) => {
+              const active = activePresetId === preset.id;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => onChange(preset.value)}
+                  className={`flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-[11px] ${
+                    active
+                      ? "border-sky-500 text-white"
+                      : "border-gray-700 text-gray-300 hover:border-gray-500"
+                  }`}
+                >
+                  <span
+                    className="h-10 w-10 rounded border border-gray-600"
+                    style={preset.previewStyle}
+                    aria-hidden
+                  />
+                  {t(`presets.${preset.labelKey}`)}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("customColorHeading")}
+          </h4>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              type="color"
+              value={customColor}
+              onChange={(e) => setCustomColor(e.target.value)}
+              className="h-10 w-14 cursor-pointer rounded border border-gray-700 bg-transparent"
+              aria-label={t("customColorPicker")}
+            />
+            <input
+              type="text"
+              value={customColor}
+              onChange={(e) => setCustomColor(e.target.value)}
+              placeholder="#rrggbb"
+              className="w-28 rounded border border-gray-700 bg-gray-900 px-2 py-1 font-mono text-sm text-white"
+              aria-label={t("customColorHex")}
+            />
+            <button
+              type="button"
+              onClick={() => applyColor(customColor)}
+              disabled={!isValidHex(customColor)}
+              className="rounded-md border border-gray-700 bg-gray-900/70 px-3 py-1.5 text-xs text-white hover:bg-gray-800 disabled:opacity-40"
+            >
+              {t("applyColor")}
+            </button>
+          </div>
+
+          {recent.length > 0 ? (
+            <div className="mt-3">
+              <p className="mb-1 text-[11px] uppercase text-gray-500">
+                {t("recentColors")}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {recent.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => applyColor(color)}
+                    className="h-7 w-7 rounded border border-gray-700"
+                    style={{ backgroundColor: color }}
+                    title={color}
+                    aria-label={color}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("customImageHeading")}
+          </h4>
+          <p className="mb-2 text-[11px] text-gray-500">
+            {t("customImageNote")}
+          </p>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleImage(file);
+            }}
+            className="text-xs text-gray-300"
+            aria-label={t("customImageUpload")}
+          />
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/player/LottiePlayerStage.tsx
+++ b/src/components/player/LottiePlayerStage.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import type { AnimationItem, LottiePlayer } from "lottie-web";
+import type { LottieJson } from "@/lib/lottie-analyzer";
+import type { BackgroundValue, LoopMode, PlayerState } from "./types";
+
+export interface LottiePlayerHandle {
+  play: () => void;
+  pause: () => void;
+  goToFrame: (frame: number) => void;
+  stepFrame: (delta: number) => void;
+  isPaused: () => boolean;
+}
+
+interface LottiePlayerStageProps {
+  lottie: LottiePlayer | null;
+  data: LottieJson;
+  state: PlayerState;
+  onFrame: (frame: number) => void;
+  onReady: (totalFrames: number, frameRate: number) => void;
+  onPlayStateChange: (playing: boolean) => void;
+  handleRef: React.RefObject<LottiePlayerHandle | null>;
+}
+
+function backgroundStyle(bg: BackgroundValue): React.CSSProperties {
+  if (bg.kind === "transparent") {
+    return {
+      backgroundImage:
+        "linear-gradient(45deg, #444 25%, transparent 25%), linear-gradient(-45deg, #444 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #444 75%), linear-gradient(-45deg, transparent 75%, #444 75%)",
+      backgroundSize: "20px 20px",
+      backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0",
+      backgroundColor: "#222",
+    };
+  }
+  if (bg.kind === "color") {
+    return { backgroundColor: bg.color ?? "#111" };
+  }
+  if (bg.kind === "image" && bg.imageUrl) {
+    return {
+      backgroundImage: `url(${bg.imageUrl})`,
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+    };
+  }
+  return {};
+}
+
+function mapLoopMode(mode: LoopMode): { loop: boolean } {
+  switch (mode) {
+    case "loop":
+    case "pingpong":
+      return { loop: true };
+    case "once":
+      return { loop: false };
+  }
+}
+
+export function LottiePlayerStage({
+  lottie,
+  data,
+  state,
+  onFrame,
+  onReady,
+  onPlayStateChange,
+  handleRef,
+}: LottiePlayerStageProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<AnimationItem | null>(null);
+  const totalFramesRef = useRef(0);
+
+  useEffect(() => {
+    if (!lottie || !containerRef.current) return;
+
+    if (animationRef.current) {
+      animationRef.current.destroy();
+      animationRef.current = null;
+    }
+
+    containerRef.current.innerHTML = "";
+    const instance = lottie.loadAnimation({
+      container: containerRef.current,
+      renderer: "svg",
+      autoplay: true,
+      animationData: data as unknown as object,
+      ...mapLoopMode(state.loopMode),
+    });
+
+    animationRef.current = instance;
+
+    const handleDomLoaded = () => {
+      const total = instance.totalFrames;
+      const fr = instance.frameRate;
+      totalFramesRef.current = total;
+      onReady(total, fr);
+      onPlayStateChange(!instance.isPaused);
+    };
+
+    const handleEnter = (event: unknown) => {
+      const e = event as { currentTime?: number };
+      if (typeof e?.currentTime === "number") {
+        onFrame(e.currentTime);
+      }
+    };
+
+    const handleComplete = () => {
+      onPlayStateChange(false);
+    };
+
+    const handleLoopComplete = () => {
+      if (state.loopMode === "pingpong") {
+        const current = instance.playDirection;
+        instance.setDirection(current === 1 ? -1 : 1);
+        instance.play();
+      }
+    };
+
+    instance.addEventListener("DOMLoaded", handleDomLoaded);
+    instance.addEventListener("enterFrame", handleEnter);
+    instance.addEventListener("complete", handleComplete);
+    instance.addEventListener("loopComplete", handleLoopComplete);
+
+    return () => {
+      instance.removeEventListener("DOMLoaded", handleDomLoaded);
+      instance.removeEventListener("enterFrame", handleEnter);
+      instance.removeEventListener("complete", handleComplete);
+      instance.removeEventListener("loopComplete", handleLoopComplete);
+      instance.destroy();
+      animationRef.current = null;
+    };
+  }, [
+    lottie,
+    data,
+    state.loopMode,
+    onFrame,
+    onReady,
+    onPlayStateChange,
+  ]);
+
+  useEffect(() => {
+    if (animationRef.current) {
+      animationRef.current.setSpeed(state.speed);
+    }
+  }, [state.speed]);
+
+  useEffect(() => {
+    if (animationRef.current) {
+      animationRef.current.setDirection(state.direction);
+    }
+  }, [state.direction]);
+
+  useEffect(() => {
+    if (!animationRef.current) return;
+    const total = totalFramesRef.current;
+    if (total <= 0) return;
+    if (state.segment) {
+      const from = Math.max(0, Math.min(state.segment.from, total));
+      const to = Math.max(from + 1, Math.min(state.segment.to, total));
+      animationRef.current.playSegments([from, to], true);
+    } else {
+      animationRef.current.playSegments([0, total], true);
+    }
+  }, [state.segment]);
+
+  useImperativeHandle(
+    handleRef,
+    (): LottiePlayerHandle => ({
+      play: () => {
+        animationRef.current?.play();
+        onPlayStateChange(true);
+      },
+      pause: () => {
+        animationRef.current?.pause();
+        onPlayStateChange(false);
+      },
+      goToFrame: (frame: number) => {
+        animationRef.current?.goToAndStop(frame, true);
+        onPlayStateChange(false);
+      },
+      stepFrame: (delta: number) => {
+        if (!animationRef.current) return;
+        const current = animationRef.current.currentFrame;
+        const next = current + delta;
+        animationRef.current.goToAndStop(next, true);
+        onPlayStateChange(false);
+      },
+      isPaused: () => animationRef.current?.isPaused ?? true,
+    }),
+    [onPlayStateChange],
+  );
+
+  const bgStyle = useMemo(() => backgroundStyle(state.background), [state.background]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-96 w-full rounded-lg border border-gray-700"
+      style={bgStyle}
+      role="img"
+    />
+  );
+}

--- a/src/components/player/PlayerControlsSection.tsx
+++ b/src/components/player/PlayerControlsSection.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { SectionCard } from "@/components/analysis/SectionCard";
+import type { LottiePlayerHandle } from "./LottiePlayerStage";
+import type { LoopMode, PlayerState } from "./types";
+
+interface PlayerControlsSectionProps {
+  state: PlayerState;
+  onChange: (partial: Partial<PlayerState>) => void;
+  playerHandle: React.RefObject<LottiePlayerHandle | null>;
+  currentFrame: number;
+  totalFrames: number;
+  frameRate: number;
+  isPlaying: boolean;
+}
+
+const SPEEDS = [0.25, 0.5, 1, 2, 4] as const;
+const LOOP_MODES: LoopMode[] = ["loop", "once", "pingpong"];
+
+export function PlayerControlsSection({
+  state,
+  onChange,
+  playerHandle,
+  currentFrame,
+  totalFrames,
+  frameRate,
+  isPlaying,
+}: PlayerControlsSectionProps) {
+  const t = useTranslations("analysis.playerControls");
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement | null)?.tagName ?? "";
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+      if (e.code === "Space") {
+        e.preventDefault();
+        if (playerHandle.current?.isPaused()) {
+          playerHandle.current?.play();
+        } else {
+          playerHandle.current?.pause();
+        }
+      } else if (e.code === "ArrowLeft") {
+        e.preventDefault();
+        playerHandle.current?.stepFrame(e.shiftKey ? -10 : -1);
+      } else if (e.code === "ArrowRight") {
+        e.preventDefault();
+        playerHandle.current?.stepFrame(e.shiftKey ? 10 : 1);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [playerHandle]);
+
+  const currentSeconds =
+    frameRate > 0 ? (currentFrame / frameRate).toFixed(2) : "0.00";
+  const totalSeconds =
+    frameRate > 0 && totalFrames > 0
+      ? (totalFrames / frameRate).toFixed(2)
+      : "0.00";
+
+  const handleScrub = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    playerHandle.current?.goToFrame(value);
+  };
+
+  const segmentFrom = state.segment?.from ?? 0;
+  const segmentTo = state.segment?.to ?? (totalFrames > 0 ? totalFrames : 0);
+
+  return (
+    <SectionCard
+      id="analysis-player-controls"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="space-y-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              if (isPlaying) {
+                playerHandle.current?.pause();
+              } else {
+                playerHandle.current?.play();
+              }
+            }}
+            className="rounded-md border border-gray-700 bg-gray-900/70 px-4 py-1.5 text-sm text-white hover:bg-gray-800"
+          >
+            {isPlaying ? t("pause") : t("play")}
+          </button>
+
+          <div className="flex items-center gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5">
+            {SPEEDS.map((sp) => (
+              <button
+                key={sp}
+                type="button"
+                onClick={() => onChange({ speed: sp })}
+                className={`rounded px-2 py-1 text-xs ${
+                  state.speed === sp
+                    ? "bg-gray-700 text-white"
+                    : "text-gray-400 hover:text-white"
+                }`}
+              >
+                {sp}x
+              </button>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() =>
+              onChange({ direction: state.direction === 1 ? -1 : 1 })
+            }
+            className="rounded-md border border-gray-700 bg-gray-900/70 px-3 py-1.5 text-xs text-white hover:bg-gray-800"
+            aria-label={t("directionToggle")}
+          >
+            {state.direction === 1 ? t("forward") : t("backward")}
+          </button>
+
+          <div className="flex items-center gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5">
+            {LOOP_MODES.map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => onChange({ loopMode: mode })}
+                className={`rounded px-2 py-1 text-xs ${
+                  state.loopMode === mode
+                    ? "bg-gray-700 text-white"
+                    : "text-gray-400 hover:text-white"
+                }`}
+              >
+                {t(`loopMode.${mode}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between text-xs text-gray-400">
+            <span>
+              {t("frame")} <span className="text-white">{Math.round(currentFrame)}</span> /{" "}
+              {totalFrames}
+            </span>
+            <span className="font-mono">
+              {currentSeconds}s / {totalSeconds}s
+            </span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={totalFrames > 0 ? totalFrames : 100}
+            step={1}
+            value={Math.round(currentFrame)}
+            onChange={handleScrub}
+            className="mt-1 w-full accent-sky-500"
+            aria-label={t("scrub")}
+          />
+        </div>
+
+        <fieldset className="rounded-md border border-gray-700 bg-gray-900/40 p-3">
+          <legend className="px-1 text-xs uppercase tracking-wide text-gray-400">
+            {t("segmentLegend")}
+          </legend>
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              <input
+                type="checkbox"
+                checked={state.segment !== null}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onChange({
+                      segment: {
+                        from: 0,
+                        to: Math.max(1, totalFrames),
+                      },
+                    });
+                  } else {
+                    onChange({ segment: null });
+                  }
+                }}
+              />
+              {t("segmentEnable")}
+            </label>
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              {t("from")}
+              <input
+                type="number"
+                min={0}
+                max={totalFrames}
+                value={segmentFrom}
+                disabled={state.segment === null}
+                onChange={(e) =>
+                  onChange({
+                    segment: {
+                      from: Number(e.target.value),
+                      to: segmentTo,
+                    },
+                  })
+                }
+                className="w-20 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-white disabled:opacity-40"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              {t("to")}
+              <input
+                type="number"
+                min={0}
+                max={totalFrames}
+                value={segmentTo}
+                disabled={state.segment === null}
+                onChange={(e) =>
+                  onChange({
+                    segment: {
+                      from: segmentFrom,
+                      to: Number(e.target.value),
+                    },
+                  })
+                }
+                className="w-20 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-white disabled:opacity-40"
+              />
+            </label>
+          </div>
+        </fieldset>
+
+        <p className="text-[11px] text-gray-500">{t("shortcutsHelp")}</p>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/player/types.ts
+++ b/src/components/player/types.ts
@@ -1,0 +1,17 @@
+export type LoopMode = "loop" | "once" | "pingpong";
+
+export type BackgroundKind = "transparent" | "color" | "image";
+
+export interface BackgroundValue {
+  kind: BackgroundKind;
+  color?: string;
+  imageUrl?: string;
+}
+
+export interface PlayerState {
+  speed: number;
+  direction: 1 | -1;
+  loopMode: LoopMode;
+  segment: { from: number; to: number } | null;
+  background: BackgroundValue;
+}

--- a/src/lib/snippets/generate.test.ts
+++ b/src/lib/snippets/generate.test.ts
@@ -38,10 +38,22 @@ describe("generateSnippet", () => {
     expect(out.code).toContain("CGRect(x: 0, y: 0, width: 400, height: 300)");
   });
 
-  it("produces kotlin snippet with R.raw lookup", () => {
+  it("produces kotlin snippet with a valid Android resource identifier", () => {
     const out = generateSnippet("kotlin", input);
-    expect(out.code).toContain("R.raw.my-lottie");
-    expect(out.code).toContain("my_lottie");
+    expect(out.code).toContain("R.raw.my_lottie");
+    expect(out.code).toContain("res/raw/my_lottie.json");
+    expect(out.code).not.toContain("R.raw.my-lottie");
+    expect(out.code).not.toMatch(/R\.raw\.[^a-z0-9_]/);
+  });
+
+  it("kotlin snippet normalizes numeric-leading and whitespace filenames", () => {
+    const out = generateSnippet("kotlin", {
+      fileName: "123 cool.json",
+      width: null,
+      height: null,
+    });
+    expect(out.code).toMatch(/R\.raw\.[a-z_][a-z0-9_]*/);
+    expect(out.code).not.toMatch(/R\.raw\.[^a-z0-9_\n]/);
   });
 
   it("handles missing dimensions and unusual filenames", () => {

--- a/src/lib/snippets/generate.test.ts
+++ b/src/lib/snippets/generate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { generateSnippet } from "./generate";
+
+const input = { fileName: "my-lottie.json", width: 400, height: 300 };
+
+describe("generateSnippet", () => {
+  it("produces react snippet with install command and dimensions", () => {
+    const out = generateSnippet("react", input);
+    expect(out.language).toBe("tsx");
+    expect(out.install).toContain("lottie-react");
+    expect(out.code).toContain('import my_lottie from "./my-lottie.json"');
+    expect(out.code).toContain("width: 400, height: 300");
+  });
+
+  it("produces next snippet with dynamic ssr false", () => {
+    const out = generateSnippet("next", input);
+    expect(out.code).toContain("\"use client\"");
+    expect(out.code).toContain("dynamic(() => import(\"lottie-react\")");
+  });
+
+  it("produces vue snippet with Vue3Lottie", () => {
+    const out = generateSnippet("vue", input);
+    expect(out.language).toBe("vue");
+    expect(out.code).toContain("Vue3Lottie");
+    expect(out.code).toContain(":width=\"400\"");
+  });
+
+  it("produces html snippet without install command", () => {
+    const out = generateSnippet("html", input);
+    expect(out.install).toBeNull();
+    expect(out.code).toContain("<lottie-player");
+    expect(out.code).toContain("width: 400px; height: 300px");
+  });
+
+  it("produces swift snippet stripping extension", () => {
+    const out = generateSnippet("swift", input);
+    expect(out.code).toContain("LottieAnimationView(name: \"my-lottie\")");
+    expect(out.code).toContain("CGRect(x: 0, y: 0, width: 400, height: 300)");
+  });
+
+  it("produces kotlin snippet with R.raw lookup", () => {
+    const out = generateSnippet("kotlin", input);
+    expect(out.code).toContain("R.raw.my-lottie");
+    expect(out.code).toContain("my_lottie");
+  });
+
+  it("handles missing dimensions and unusual filenames", () => {
+    const out = generateSnippet("html", {
+      fileName: "123 cool.json",
+      width: null,
+      height: null,
+    });
+    expect(out.code).toContain("width: 100%; height: 100%");
+    const swift = generateSnippet("swift", {
+      fileName: "no-ext",
+      width: null,
+      height: null,
+    });
+    expect(swift.code).toContain("LottieAnimationView(name: \"no-ext\")");
+  });
+});

--- a/src/lib/snippets/generate.ts
+++ b/src/lib/snippets/generate.ts
@@ -1,0 +1,167 @@
+export type SnippetPlatform =
+  | "react"
+  | "vue"
+  | "next"
+  | "html"
+  | "swift"
+  | "kotlin";
+
+export interface SnippetInput {
+  fileName: string;
+  width: number | null;
+  height: number | null;
+}
+
+export interface SnippetOutput {
+  platform: SnippetPlatform;
+  language: "tsx" | "vue" | "html" | "swift" | "kotlin";
+  install: string | null;
+  code: string;
+}
+
+function safeVar(fileName: string): string {
+  const base = fileName.replace(/\.[^.]+$/, "");
+  const cleaned = base.replace(/[^a-zA-Z0-9]+/g, "_");
+  const trimmed = cleaned.replace(/^_+|_+$/g, "");
+  if (!trimmed) return "animation";
+  if (/^[0-9]/.test(trimmed)) return `_${trimmed}`;
+  return trimmed;
+}
+
+function dimensionStyle(width: number | null, height: number | null): string {
+  if (width && height) return `width: ${width}px; height: ${height}px`;
+  return "width: 100%; height: 100%";
+}
+
+export function generateSnippet(
+  platform: SnippetPlatform,
+  input: SnippetInput,
+): SnippetOutput {
+  const varName = safeVar(input.fileName);
+  const w = input.width ?? 300;
+  const h = input.height ?? 300;
+
+  switch (platform) {
+    case "react":
+      return {
+        platform,
+        language: "tsx",
+        install: "npm install lottie-react",
+        code: `import Lottie from "lottie-react";
+import ${varName} from "./${input.fileName}";
+
+export function ${capitalize(varName)}Animation() {
+  return <Lottie animationData={${varName}} style={{ width: ${w}, height: ${h} }} loop />;
+}
+`,
+      };
+    case "next":
+      return {
+        platform,
+        language: "tsx",
+        install: "npm install lottie-react",
+        code: `"use client";
+
+import dynamic from "next/dynamic";
+import ${varName} from "./${input.fileName}";
+
+const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
+
+export function ${capitalize(varName)}Animation() {
+  return <Lottie animationData={${varName}} style={{ width: ${w}, height: ${h} }} loop />;
+}
+`,
+      };
+    case "vue":
+      return {
+        platform,
+        language: "vue",
+        install: "npm install vue3-lottie",
+        code: `<script setup lang="ts">
+import { Vue3Lottie } from "vue3-lottie";
+import ${varName} from "./${input.fileName}";
+</script>
+
+<template>
+  <Vue3Lottie :animationData="${varName}" :width="${w}" :height="${h}" loop />
+</template>
+`,
+      };
+    case "html":
+      return {
+        platform,
+        language: "html",
+        install: null,
+        code: `<script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+<lottie-player
+  src="./${input.fileName}"
+  background="transparent"
+  speed="1"
+  style="${dimensionStyle(input.width, input.height)}"
+  loop
+  autoplay
+></lottie-player>
+`,
+      };
+    case "swift":
+      return {
+        platform,
+        language: "swift",
+        install:
+          "// Swift Package Manager\n// https://github.com/airbnb/lottie-ios",
+        code: `import Lottie
+import UIKit
+
+final class ${capitalize(varName)}ViewController: UIViewController {
+  private let animationView = LottieAnimationView(name: "${stripExtension(
+    input.fileName,
+  )}")
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    animationView.frame = CGRect(x: 0, y: 0, width: ${w}, height: ${h})
+    animationView.contentMode = .scaleAspectFit
+    animationView.loopMode = .loop
+    view.addSubview(animationView)
+    animationView.play()
+  }
+}
+`,
+      };
+    case "kotlin":
+      return {
+        platform,
+        language: "kotlin",
+        install:
+          "// build.gradle(.kts)\n// implementation(\"com.airbnb.android:lottie:6.5.2\")",
+        code: `// res/raw/${stripExtension(input.fileName)}.json 에 파일을 배치
+// layout XML
+/*
+<com.airbnb.lottie.LottieAnimationView
+    android:id="@+id/${varName}"
+    android:layout_width="${w}dp"
+    android:layout_height="${h}dp"
+    app:lottie_rawRes="@raw/${stripExtension(input.fileName)}"
+    app:lottie_autoPlay="true"
+    app:lottie_loop="true" />
+*/
+
+import com.airbnb.lottie.LottieAnimationView
+
+val animationView: LottieAnimationView = findViewById(R.id.${varName})
+animationView.setAnimation(R.raw.${stripExtension(input.fileName)})
+animationView.repeatCount = LottieDrawable.INFINITE
+animationView.playAnimation()
+`,
+      };
+  }
+}
+
+function capitalize(v: string): string {
+  if (!v) return v;
+  return v.charAt(0).toUpperCase() + v.slice(1);
+}
+
+function stripExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, "");
+}

--- a/src/lib/snippets/generate.ts
+++ b/src/lib/snippets/generate.ts
@@ -128,32 +128,36 @@ final class ${capitalize(varName)}ViewController: UIViewController {
 }
 `,
       };
-    case "kotlin":
+    case "kotlin": {
+      const resName = varName.toLowerCase();
       return {
         platform,
         language: "kotlin",
         install:
           "// build.gradle(.kts)\n// implementation(\"com.airbnb.android:lottie:6.5.2\")",
-        code: `// res/raw/${stripExtension(input.fileName)}.json 에 파일을 배치
+        code: `// Android 리소스 이름은 [a-z0-9_]만 허용됩니다.
+// 원본 파일(${input.fileName})을 res/raw/${resName}.json 으로 저장하세요.
 // layout XML
 /*
 <com.airbnb.lottie.LottieAnimationView
-    android:id="@+id/${varName}"
+    android:id="@+id/${resName}"
     android:layout_width="${w}dp"
     android:layout_height="${h}dp"
-    app:lottie_rawRes="@raw/${stripExtension(input.fileName)}"
+    app:lottie_rawRes="@raw/${resName}"
     app:lottie_autoPlay="true"
     app:lottie_loop="true" />
 */
 
 import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.LottieDrawable
 
-val animationView: LottieAnimationView = findViewById(R.id.${varName})
-animationView.setAnimation(R.raw.${stripExtension(input.fileName)})
+val animationView: LottieAnimationView = findViewById(R.id.${resName})
+animationView.setAnimation(R.raw.${resName})
 animationView.repeatCount = LottieDrawable.INFINITE
 animationView.playAnimation()
 `,
       };
+    }
   }
 }
 


### PR DESCRIPTION
## 📌 Summary

> JSO-1의 Phase C로, 업로드된 Lottie를 실제로 제어할 수 있도록 Section 6(재생 컨트롤), Section 7(배경 변경), Section 8(코드 스니펫)을 추가한다.

## 📋 Changes

- `./src/components/player/types.ts`: `PlayerState`, `LoopMode`, `BackgroundValue` 공용 타입
- `./src/components/player/LottiePlayerStage.tsx`: 기존 `AnimationContainer`를 대체하는 제어형 플레이어. `useImperativeHandle`로 play/pause/goToFrame/stepFrame 노출, `playSegments`로 구간 반복, `loopComplete`에서 ping-pong 방향 전환, 프레임 브로드캐스트
- `./src/components/player/PlayerControlsSection.tsx`: 재생/일시정지, 0.25x~4x 프리셋, 방향 토글, Loop/Once/Ping-pong 모드, 프레임 스크럽 슬라이더 + 초 단위 표기, 구간 반복 범위 입력, 전역 키보드 단축키(Space/←→/Shift+←→ — input/textarea 포커스 시 bail)
- `./src/components/player/BackgroundSection.tsx`: 7개 프리셋(투명 체커보드 + 라이트 2종 + 다크 2종 + 흰/검), HEX/RGB 피커 + Apply 검증, localStorage 기반 최근 색상, 로컬 blob URL 전용 이미지 업로드(언마운트 시 revoke)
- `./src/lib/snippets/generate.ts`: 파일명/차원 반영 스니펫 생성기 (React, Next.js `dynamic ssr:false`, Vue 3 vue3-lottie, `<lottie-player>`, Swift Lottie, Kotlin Airbnb Lottie) — 식별자 정규화/확장자 제거 포함
- `./src/components/analysis/SnippetSection.tsx`: 탭 UI, 설치 커맨드 강조, 간이 키워드 syntax highlight, 복사 + \"Copied!\" 토스트
- `./src/components/analysis/AnalysisResult.tsx`: `fileName` prop 추가, Compatibility 다음에 `SnippetSection` 배치
- `./src/app/[locale]/page.tsx`: 업로드 후에는 기존 Suspense+`AnimationContainer`를 `LottiePlayerStage`로 교체, `playerHandleRef` 보유, PlayerControls/Background를 뷰어 바로 아래 배치, 드래그/드롭/파일 선택 흐름 보존
- `./src/lib/snippets/generate.test.ts`: 모든 플랫폼 + 파일명/차원 edge case 테스트 7 케이스
- `./messages/en.json`, `./messages/ko.json`: `analysis.playerControls`, `analysis.background`, `analysis.snippets` namespace 추가

## 🧠 Context & Background

Phase B에서 분석 결과를 \"자동 생성된 콘텐츠\"로 만들었고, Phase C는 사용자가 업로드 파일을 실제로 만지고(재생 컨트롤), 컨텍스트를 바꿔보고(배경), 자기 코드에 바로 붙여넣게(스니펫) 함으로써 체류 시간을 3-5분으로 확장하는 이슈 목표의 나머지 절반을 완성한다. 최종 다듬기(i18n 정합/다크모드 상세/반응형 세부)는 Phase D로 이어진다.

## ✅ How to Test

1. `npm install`
2. `npm test` → vitest 37/37 (Phase A 30 + snippet generator 7)
3. `npx tsc --noEmit` 타입 에러 없음
4. `npm run lint` 경고/에러 없음
5. `npm run build` 프로덕션 빌드 성공
6. `npm run dev` → Lottie 업로드 → 뷰어 아래 Section 6/7 collapsible 3개, 하단 분석 결과 마지막에 Section 8 확인
7. 재생 컨트롤: 속도 버튼(0.25/0.5/1/2/4), 방향 토글, Loop/Once/Ping-pong 전환, 슬라이더 스크럽, 구간 반복 체크박스 + 범위 입력, Space/←→/Shift+←→ 키보드 동작
8. 배경: 7개 프리셋 클릭 시 즉시 반영, HEX 색상 입력 + Apply, 최근 색상 재선택, 이미지 업로드 후 blob URL 배경
9. 스니펫: 탭 전환 시 코드와 설치 커맨드 전환, 복사 버튼 → \"Copied!\" 표시, 업로드한 파일명/차원이 코드에 반영

## 🔗 Related Issues

- Related: JSO-1 (Phase C / 4단계 분할 중 3단계)

## 🙌 Additional Notes

- `<lottie-player>`(Section 8) 스니펫은 CDN 링크 기반이라 install 커맨드가 없어 `install: null`로 빈 블록을 숨긴다.
- `BackgroundSection`은 커스텀 이미지를 `URL.createObjectURL`로만 처리하고 언마운트 시 revoke하여 서버 전송이 없음 (개인정보 보호 기조 유지).
- Phase B의 Compatibility에서 리뷰어가 지적한 `<p>` inside `<ul>` 이슈는 Phase D에서 정리 예정.