### PR TITLE
feature/JSO-1-phase-d-common

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,8 +3,12 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --surface: #111827;
+  --surface-strong: #1f2937;
+  --muted: #9ca3af;
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -12,13 +16,6 @@
   --color-foreground: var(--foreground);
   --font-sans: "Inter", sans-serif;
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/components/analysis/CompatibilitySection.tsx
+++ b/src/components/analysis/CompatibilitySection.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslations } from "next-intl";
 import type {
   PlatformCompatibility,
+  PlatformFeatureSupport,
   PlatformKey,
   PlatformSupportLevel,
 } from "@/lib/lottie-analyzer";
 import { SectionCard } from "./SectionCard";
+
+type TranslateFn = ReturnType<typeof useTranslations>;
 
 interface CompatibilitySectionProps {
   compatibility: PlatformCompatibility;
@@ -48,6 +51,7 @@ export function CompatibilitySection({
 }: CompatibilitySectionProps) {
   const t = useTranslations("analysis.compatibility");
   const [expanded, setExpanded] = useState<PlatformKey | null>(null);
+  const detailPanelId = useId();
 
   const detected = compatibility.features.filter((f) => f.detectedInFile);
 
@@ -79,6 +83,7 @@ export function CompatibilitySection({
               onClick={() => setExpanded(isOpen ? null : platform)}
               className={`flex flex-col items-start rounded-lg p-4 text-left ring-1 ${style.bg} ${style.ring}`}
               aria-expanded={isOpen}
+              aria-controls={detailPanelId}
             >
               <div className="flex w-full items-center justify-between">
                 <span className="text-sm font-semibold text-white">
@@ -103,63 +108,16 @@ export function CompatibilitySection({
       </div>
 
       {expanded ? (
-        <div className="mt-4 rounded-md border border-gray-700 bg-gray-900/40 p-4">
-          <h4 className="mb-2 text-sm font-semibold text-white">
-            {t("detectedIssues", { platform: t(`platforms.${expanded}`) })}
-          </h4>
-          {detected.length === 0 ? (
-            <p className="text-xs text-gray-400">{t("noIssues")}</p>
-          ) : (
-            <ul className="space-y-2">
-              {detected
-                .filter((f) => f[expanded!] !== "supported")
-                .map((f) => {
-                  const level = f[expanded!];
-                  const style = LEVEL_STYLES[level];
-                  return (
-                    <li
-                      key={f.feature}
-                      className="flex flex-wrap items-center gap-3 rounded border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm"
-                    >
-                      <span className={`font-semibold ${style.text}`}>
-                        {style.icon}
-                      </span>
-                      <span className="text-gray-200">{f.feature}</span>
-                      <span className="ml-auto text-xs text-gray-400">
-                        {t(`levels.${level}`)}
-                      </span>
-                      {f.relatedLayerIndexes.length > 0 ? (
-                        <div className="flex w-full flex-wrap gap-1 pt-1">
-                          {f.relatedLayerIndexes.slice(0, 6).map((idx) => (
-                            <button
-                              key={idx}
-                              type="button"
-                              onClick={() => onJumpToLayer(idx)}
-                              className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[10px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
-                            >
-                              #{idx}
-                            </button>
-                          ))}
-                          {f.relatedLayerIndexes.length > 6 ? (
-                            <span className="text-[10px] text-gray-500">
-                              +{f.relatedLayerIndexes.length - 6}
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              {detected.filter((f) => f[expanded!] !== "supported").length ===
-              0 ? (
-                <p className="text-xs text-gray-400">{t("noIssues")}</p>
-              ) : null}
-            </ul>
-          )}
-        </div>
+        <CompatibilityPlatformDetail
+          panelId={detailPanelId}
+          platform={expanded}
+          features={detected}
+          onJumpToLayer={onJumpToLayer}
+          t={t}
+        />
       ) : null}
 
-      <div className="mt-5 overflow-hidden rounded-md border border-gray-800">
+      <div className="mt-5 overflow-x-auto rounded-md border border-gray-800">
         <table className="min-w-full text-left text-sm">
           <thead className="bg-gray-900/80 text-xs uppercase tracking-wide text-gray-400">
             <tr>
@@ -200,5 +158,77 @@ export function CompatibilitySection({
         </table>
       </div>
     </SectionCard>
+  );
+}
+
+interface CompatibilityPlatformDetailProps {
+  panelId: string;
+  platform: PlatformKey;
+  features: PlatformFeatureSupport[];
+  onJumpToLayer: (layerIndex: number) => void;
+  t: TranslateFn;
+}
+
+function CompatibilityPlatformDetail({
+  panelId,
+  platform,
+  features,
+  onJumpToLayer,
+  t,
+}: CompatibilityPlatformDetailProps) {
+  const issues = features.filter((f) => f[platform] !== "supported");
+
+  return (
+    <div
+      id={panelId}
+      className="mt-4 rounded-md border border-gray-700 bg-gray-900/40 p-4"
+    >
+      <h4 className="mb-2 text-sm font-semibold text-white">
+        {t("detectedIssues", { platform: t(`platforms.${platform}`) })}
+      </h4>
+      {issues.length === 0 ? (
+        <p className="text-xs text-gray-400">{t("noIssues")}</p>
+      ) : (
+        <ul className="space-y-2">
+          {issues.map((f) => {
+            const level = f[platform];
+            const style = LEVEL_STYLES[level];
+            return (
+              <li
+                key={f.feature}
+                className="flex flex-wrap items-center gap-3 rounded border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm"
+              >
+                <span className={`font-semibold ${style.text}`}>
+                  {style.icon}
+                </span>
+                <span className="text-gray-200">{f.feature}</span>
+                <span className="ml-auto text-xs text-gray-400">
+                  {t(`levels.${level}`)}
+                </span>
+                {f.relatedLayerIndexes.length > 0 ? (
+                  <div className="flex w-full flex-wrap gap-1 pt-1">
+                    {f.relatedLayerIndexes.slice(0, 6).map((idx) => (
+                      <button
+                        key={idx}
+                        type="button"
+                        onClick={() => onJumpToLayer(idx)}
+                        className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[10px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
+                      >
+                        #{idx}
+                      </button>
+                    ))}
+                    {f.relatedLayerIndexes.length > 6 ? (
+                      <span className="text-[10px] text-gray-500">
+                        +{f.relatedLayerIndexes.length - 6}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/src/components/analysis/PerformanceSection.tsx
+++ b/src/components/analysis/PerformanceSection.tsx
@@ -50,7 +50,7 @@ export function PerformanceSection({ score }: PerformanceSectionProps) {
           </h4>
           <ul className="space-y-2">
             {sortedBreakdown.map((metric) => {
-              const contributionPct = (metric.contribution / 100) * 100;
+              const contributionPct = metric.score;
               return (
                 <li key={metric.key}>
                   <div className="flex items-center justify-between text-xs">


### PR DESCRIPTION
## 📌 Summary

> JSO-1의 Phase D로, Phase B 리뷰에서 남겨진 컴플라이언스 이슈를 정리하고 성능 점수 시각화·모바일 반응형·다크 테마 일관성을 마무리한다.

## 📋 Changes

- `./src/components/analysis/CompatibilitySection.tsx`
  - 확장 패널을 `CompatibilityPlatformDetail` 서브컴포넌트로 분리하여, 감지 이슈가 0건일 때 `<p>`가 `<ul>` 직속 자식으로 렌더되던 HTML/a11y 이슈 해결
  - 필터된 이슈 배열을 서브컴포넌트 내부에서 계산, 빈 상태는 `<ul>` 바깥 `<p>`로 렌더
  - 각 플랫폼 요약 카드의 `aria-controls`를 `useId` 기반으로 disclosure 패널에 연결 (스크린리더 연결)
  - 전체 호환 매트릭스 테이블: 모바일에서 가로 스크롤되도록 `overflow-x-auto` 적용
- `./src/components/analysis/PerformanceSection.tsx`: 메트릭 프로그레스 바 폭을 `metric.contribution`이 아닌 `metric.score` 기반으로 재조정 — 가중치에 상관없이 0~100% 범위로 정상 표시
- `./src/app/globals.css`: `prefers-color-scheme` 분기를 제거하고 다크 팔레트를 `:root`에 고정, `color-scheme: dark` 선언 추가 — 분석 도구 UX가 라이트/다크 OS 모두에서 동일하게 다크 테마로 렌더

## 🧠 Context & Background

Phase B/C에서 기능이 완성되었고, 이번 Phase D는:
1. Phase B 리뷰(#23)에서 남겨진 `<ul>/<p>` 구조 오류와 `aria-controls` 누락을 해결
2. Performance 프로그레스 바가 시각적으로 의미를 전달하도록 정규화
3. 분석 도구 성격상 다크 테마 일관성 확보
4. 호환성 매트릭스가 모바일에서 잘리지 않도록 마무리

이슈의 \"다크/라이트 모드 스타일\"은 Section 7 배경 프리셋(Phase C에서 구현됨)과 루트 테마 일관성으로 해석하여 분석 UI는 다크 고정, 사용자는 배경 섹션에서 라이트/다크 톤 프리셋을 선택할 수 있다.
\"반응형(모바일: 세로 스택)\"은 기존 섹션들이 이미 Tailwind breakpoint로 세로 스택되도록 설계되어 있어, 이번 PR에서는 좁은 화면에서 overflow가 발생하는 호환성 테이블만 추가로 처리했다.

## ✅ How to Test

1. `npm install`
2. `npm test` → 38/38 통과
3. `npx tsc --noEmit` 타입 에러 없음
4. `npm run lint` 경고/에러 없음
5. `npm run build` 프로덕션 빌드 성공
6. `npm run dev` → 업로드 후:
   - 호환성 섹션에서 Web/iOS/Android 카드 클릭 시 `aria-controls`로 연결된 상세 패널 확장, 감지 이슈가 없을 때도 HTML 구조 유효
   - 성능 섹션의 프로그레스 바가 score 기준 0~100% 범위로 표시되어 A 메트릭은 가득 차고 F 메트릭은 바닥
   - 모바일 폭(375px)에서 호환 매트릭스가 가로 스크롤로 읽힘
   - OS 라이트 모드에서도 분석 UI가 다크 팔레트 유지

## 🔗 Related Issues

- Related: JSO-1 (Phase D / 4단계 분할 중 마지막)

## 🙌 Additional Notes

- \"배포 및 AdSense 재심사\"는 이슈의 별도 단계(\"🚀 배포 및 AdSense 재심사\")로, 이 PR은 해당 단계 직전의 기능 완성/안정화까지 포함.
- Phase A/B/C/D 병합 후 daily/2026-04-20 → dev 통합은 후속 단계에서 진행.