### PR TITLE
release: dev → main (JSO-1 Lottie analyzer)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,152 @@
 {
+  "analysis": {
+    "metadata": {
+      "title": "Animation Metadata",
+      "subtitle": "Auto-extracted facts about your Lottie file",
+      "version": "Lottie Spec",
+      "dimensions": "Dimensions",
+      "frameRate": "Frame Rate",
+      "totalFrames": "Total Frames",
+      "duration": "Duration",
+      "layerCount": "Layer Count",
+      "assetCount": "Assets",
+      "assetBreakdown": "{images} images · {precomps} precomps",
+      "embeddedImages": "Embedded Images",
+      "markers": "Markers",
+      "fileSize": "File Size",
+      "is3D": "3D Layers",
+      "yes": "Yes",
+      "no": "No",
+      "layerTypesHeading": "Layers by Type"
+    },
+    "layers": {
+      "title": "Layer Breakdown",
+      "subtitle": "{count} layers detected",
+      "listMode": "List",
+      "treeMode": "Tree",
+      "columnName": "Name",
+      "columnType": "Type",
+      "columnFrames": "Frames",
+      "columnBlend": "Blend",
+      "column3D": "3D",
+      "columnEffects": "FX",
+      "columnMasks": "Masks",
+      "empty": "No layers in this animation.",
+      "pageStatus": "Showing {from}–{to} of {total}",
+      "prev": "Prev",
+      "next": "Next",
+      "clearHighlight": "Clear highlight"
+    },
+    "performance": {
+      "title": "Performance Score",
+      "subtitle": "Weighted signals that predict runtime cost on low-end devices",
+      "breakdownHeading": "Metric contribution",
+      "metric": {
+        "layerCount": "Layer count",
+        "expressions": "Expression usage",
+        "effects": "Effects",
+        "masks": "Masks",
+        "is3D": "3D layers",
+        "embeddedImages": "Embedded images",
+        "frameRate": "Frame rate"
+      },
+      "rawValue": "raw: {value}"
+    },
+    "optimization": {
+      "title": "Optimization Suggestions",
+      "subtitle": "{count} issues worth reviewing",
+      "allClear": "No optimization issues detected — this file is in great shape.",
+      "severity": {
+        "info": "info",
+        "warning": "warning",
+        "error": "error"
+      },
+      "what": "What",
+      "why": "Why it matters",
+      "how": "How to fix",
+      "relatedLayers": "Jump to layer",
+      "codes": {
+        "embeddedImages": {
+          "title": "Embedded raster images",
+          "metric": "{value} embedded",
+          "what": "Some images are base64-embedded directly in the JSON.",
+          "why": "Embedded images make the JSON much larger, block fast decoding, and defeat browser image caching.",
+          "how": "Export images as external assets or replace them with vector shape layers when possible."
+        },
+        "unnamedLayers": {
+          "title": "Unnamed / default-named layers",
+          "metric": "{value} layers",
+          "what": "Layers still use AE default names like \"Shape Layer 1\".",
+          "why": "Without meaningful names the JSON is hard to inspect and runtime platforms cannot target individual layers.",
+          "how": "Rename layers in After Effects to describe what they represent before exporting."
+        },
+        "expressions": {
+          "title": "Expression usage",
+          "metric": "{value} expressions",
+          "what": "Expressions (`x` fields) are used in one or more layers.",
+          "why": "Mobile Lottie renderers do not execute expressions and will silently drop the animation.",
+          "how": "Pre-bake expressions into keyframes via \"Convert Expression to Keyframes\" or Lottie's Bodymovin baker."
+        },
+        "hiddenLayers": {
+          "title": "Hidden layers shipping in the file",
+          "metric": "{value} hidden",
+          "what": "Layers are marked hidden (`hd: true`) but still included in the JSON.",
+          "why": "Hidden layers add parse/render cost for something the user never sees.",
+          "how": "Delete them in After Effects if they are not needed for runtime logic."
+        },
+        "duplicateShapePaths": {
+          "title": "Duplicate shape paths",
+          "metric": "{value} duplicates",
+          "what": "The same shape path appears more than once in the same layer.",
+          "why": "Duplicate geometry doubles draw-calls with no visual benefit.",
+          "how": "Combine into a single shape or reuse via a precomp."
+        },
+        "excessiveKeyframes": {
+          "title": "Excessive keyframes",
+          "metric": "{value} keyframes",
+          "what": "One or more layers contain very dense keyframe data.",
+          "why": "Large keyframe arrays increase JSON size and CPU cost on low-end devices.",
+          "how": "Simplify the animation curve, drop non-essential keyframes, or use expressions pre-baked at a lower sample rate."
+        },
+        "largeImageResize": {
+          "title": "Oversized image assets",
+          "metric": "{value} assets",
+          "what": "Some image assets are significantly larger than the composition.",
+          "why": "Shipping 2× or larger images wastes bandwidth and memory on every render.",
+          "how": "Resize the PNG/JPG to at most 2× the rendered dimensions before importing."
+        },
+        "missingMarkers": {
+          "title": "No markers defined",
+          "metric": "",
+          "what": "The animation has no named markers.",
+          "why": "Markers let developers jump to specific segments without guessing frame numbers.",
+          "how": "Add markers in After Effects for each meaningful segment (intro, loop, outro, etc.)."
+        }
+      }
+    },
+    "compatibility": {
+      "title": "Platform Compatibility",
+      "subtitle": "How this file behaves on Web, iOS, and Android Lottie runtimes",
+      "officialDoc": "Airbnb docs →",
+      "platforms": {
+        "web": "Web",
+        "ios": "iOS",
+        "android": "Android"
+      },
+      "levels": {
+        "supported": "Fully supported",
+        "partial": "Partial support",
+        "unsupported": "Not supported"
+      },
+      "issueBreakdown": "{unsupported} unsupported · {partial} partial",
+      "detectedIssues": "Detected issues on {platform}",
+      "noIssues": "No platform issues detected in this file.",
+      "columnFeature": "Feature",
+      "columnDetected": "In file",
+      "yes": "Yes",
+      "no": "No"
+    }
+  },
   "common": {
     "backToHome": "← Back to Home",
     "backToBlog": "← Back to Blog",

--- a/messages/en.json
+++ b/messages/en.json
@@ -145,6 +145,64 @@
       "columnDetected": "In file",
       "yes": "Yes",
       "no": "No"
+    },
+    "playerControls": {
+      "title": "Playback Controls",
+      "subtitle": "Speed, direction, loop mode and frame scrubbing",
+      "play": "Play",
+      "pause": "Pause",
+      "directionToggle": "Toggle direction",
+      "forward": "Forward →",
+      "backward": "← Reverse",
+      "loopMode": {
+        "loop": "Loop",
+        "once": "Once",
+        "pingpong": "Ping-pong"
+      },
+      "frame": "Frame",
+      "scrub": "Scrub frame",
+      "segmentLegend": "Loop a segment",
+      "segmentEnable": "Enable segment loop",
+      "from": "From",
+      "to": "To",
+      "shortcutsHelp": "Shortcuts — Space: play/pause, ←/→: step 1 frame, Shift+←/→: step 10 frames"
+    },
+    "background": {
+      "title": "Background",
+      "subtitle": "Check your animation against different canvases",
+      "presetsHeading": "Presets",
+      "presets": {
+        "transparent": "Transparent",
+        "white": "White",
+        "black": "Black",
+        "lightTone1": "Light 1",
+        "lightTone2": "Light 2",
+        "darkTone1": "Dark 1",
+        "darkTone2": "Dark 2"
+      },
+      "customColorHeading": "Custom color",
+      "customColorPicker": "Color picker",
+      "customColorHex": "Hex color",
+      "applyColor": "Apply",
+      "recentColors": "Recently used",
+      "customImageHeading": "Custom image",
+      "customImageNote": "Images are loaded locally with blob URLs — nothing is uploaded.",
+      "customImageUpload": "Upload background image"
+    },
+    "snippets": {
+      "title": "Code Snippets",
+      "subtitle": "Drop-in code for the most common Lottie runtimes",
+      "platforms": {
+        "react": "React",
+        "next": "Next.js",
+        "vue": "Vue 3",
+        "html": "HTML",
+        "swift": "Swift (iOS)",
+        "kotlin": "Kotlin (Android)"
+      },
+      "copy": "Copy",
+      "copied": "Copied!",
+      "reflectedContext": "Generated for {file} ({width} × {height})"
     }
   },
   "common": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -145,6 +145,64 @@
       "columnDetected": "파일 내 사용",
       "yes": "예",
       "no": "아니오"
+    },
+    "playerControls": {
+      "title": "재생 컨트롤",
+      "subtitle": "속도, 방향, 반복 모드와 프레임 스크러빙",
+      "play": "재생",
+      "pause": "일시정지",
+      "directionToggle": "방향 전환",
+      "forward": "정방향 →",
+      "backward": "← 역방향",
+      "loopMode": {
+        "loop": "반복",
+        "once": "한 번",
+        "pingpong": "왕복"
+      },
+      "frame": "프레임",
+      "scrub": "프레임 스크럽",
+      "segmentLegend": "구간 반복",
+      "segmentEnable": "구간 반복 활성화",
+      "from": "시작",
+      "to": "종료",
+      "shortcutsHelp": "단축키 — Space: 재생/일시정지, ←/→: 1프레임 이동, Shift+←/→: 10프레임 이동"
+    },
+    "background": {
+      "title": "배경 변경",
+      "subtitle": "다양한 배경에서 애니메이션이 어떻게 보이는지 확인하세요",
+      "presetsHeading": "프리셋",
+      "presets": {
+        "transparent": "투명",
+        "white": "흰색",
+        "black": "검정",
+        "lightTone1": "라이트 1",
+        "lightTone2": "라이트 2",
+        "darkTone1": "다크 1",
+        "darkTone2": "다크 2"
+      },
+      "customColorHeading": "커스텀 색상",
+      "customColorPicker": "색상 피커",
+      "customColorHex": "HEX 색상",
+      "applyColor": "적용",
+      "recentColors": "최근 사용",
+      "customImageHeading": "커스텀 이미지",
+      "customImageNote": "이미지는 로컬 blob URL로만 처리되며 외부로 업로드되지 않습니다.",
+      "customImageUpload": "배경 이미지 업로드"
+    },
+    "snippets": {
+      "title": "코드 스니펫",
+      "subtitle": "주요 Lottie 런타임별 즉시 사용 가능한 코드",
+      "platforms": {
+        "react": "React",
+        "next": "Next.js",
+        "vue": "Vue 3",
+        "html": "HTML",
+        "swift": "Swift (iOS)",
+        "kotlin": "Kotlin (Android)"
+      },
+      "copy": "복사",
+      "copied": "복사 완료!",
+      "reflectedContext": "{file} ({width} × {height})용 스니펫"
     }
   },
   "common": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,4 +1,152 @@
 {
+  "analysis": {
+    "metadata": {
+      "title": "애니메이션 메타데이터",
+      "subtitle": "업로드한 Lottie 파일에서 자동 추출한 정보",
+      "version": "Lottie 스펙",
+      "dimensions": "크기",
+      "frameRate": "프레임레이트",
+      "totalFrames": "총 프레임 수",
+      "duration": "재생 시간",
+      "layerCount": "레이어 수",
+      "assetCount": "에셋",
+      "assetBreakdown": "이미지 {images}개 · 프리콤프 {precomps}개",
+      "embeddedImages": "임베디드 이미지",
+      "markers": "마커",
+      "fileSize": "파일 크기",
+      "is3D": "3D 레이어",
+      "yes": "있음",
+      "no": "없음",
+      "layerTypesHeading": "타입별 레이어"
+    },
+    "layers": {
+      "title": "레이어 분석",
+      "subtitle": "총 {count}개 레이어",
+      "listMode": "리스트",
+      "treeMode": "트리",
+      "columnName": "이름",
+      "columnType": "타입",
+      "columnFrames": "프레임",
+      "columnBlend": "블렌딩",
+      "column3D": "3D",
+      "columnEffects": "이펙트",
+      "columnMasks": "마스크",
+      "empty": "이 애니메이션에는 레이어가 없습니다.",
+      "pageStatus": "{from}–{to} / {total}",
+      "prev": "이전",
+      "next": "다음",
+      "clearHighlight": "하이라이트 해제"
+    },
+    "performance": {
+      "title": "성능 점수",
+      "subtitle": "저사양 기기 기준 런타임 비용을 예측하는 가중 지표",
+      "breakdownHeading": "메트릭별 기여도",
+      "metric": {
+        "layerCount": "레이어 수",
+        "expressions": "Expression 사용",
+        "effects": "이펙트",
+        "masks": "마스크",
+        "is3D": "3D 레이어",
+        "embeddedImages": "임베디드 이미지",
+        "frameRate": "프레임레이트"
+      },
+      "rawValue": "원시값: {value}"
+    },
+    "optimization": {
+      "title": "최적화 제안",
+      "subtitle": "{count}개 항목 검토 권장",
+      "allClear": "감지된 최적화 이슈가 없습니다 — 아주 깔끔한 파일입니다.",
+      "severity": {
+        "info": "정보",
+        "warning": "경고",
+        "error": "오류"
+      },
+      "what": "무엇이",
+      "why": "왜 중요한지",
+      "how": "어떻게 해결",
+      "relatedLayers": "관련 레이어로 이동",
+      "codes": {
+        "embeddedImages": {
+          "title": "JSON에 임베디드된 이미지",
+          "metric": "{value}개 임베디드",
+          "what": "일부 이미지가 base64로 JSON에 직접 포함되어 있습니다.",
+          "why": "임베디드 이미지는 JSON 용량을 크게 늘리고 디코딩을 지연시키며 브라우저 캐싱도 막습니다.",
+          "how": "이미지를 외부 에셋으로 내보내거나 가능하다면 벡터 Shape 레이어로 대체하세요."
+        },
+        "unnamedLayers": {
+          "title": "이름이 정리되지 않은 레이어",
+          "metric": "{value}개",
+          "what": "레이어가 \"Shape Layer 1\" 같은 AE 기본 이름 그대로입니다.",
+          "why": "의미 있는 이름이 없으면 JSON 디버깅이 어렵고 런타임에서 특정 레이어를 타겟팅할 수 없습니다.",
+          "how": "After Effects에서 내보내기 전에 레이어 이름을 역할에 맞게 변경하세요."
+        },
+        "expressions": {
+          "title": "Expression 사용",
+          "metric": "{value}개 Expression",
+          "what": "일부 레이어에 Expression(`x` 필드)이 사용되었습니다.",
+          "why": "iOS/Android Lottie 런타임은 Expression을 실행하지 않아 애니메이션이 조용히 누락됩니다.",
+          "how": "\"Convert Expression to Keyframes\" 또는 Bodymovin 베이커로 키프레임으로 변환하세요."
+        },
+        "hiddenLayers": {
+          "title": "숨겨진 레이어가 포함됨",
+          "metric": "{value}개 숨김",
+          "what": "`hd: true`로 표시된 레이어가 JSON에 여전히 포함되어 있습니다.",
+          "why": "보이지 않는 레이어도 파싱/렌더 비용이 발생합니다.",
+          "how": "런타임에서 사용하지 않는다면 After Effects에서 삭제 후 다시 내보내세요."
+        },
+        "duplicateShapePaths": {
+          "title": "중복 Shape Path",
+          "metric": "{value}개 중복",
+          "what": "같은 레이어 안에서 동일한 shape path가 두 번 이상 등장합니다.",
+          "why": "중복 지오메트리는 시각적 이득 없이 드로 콜을 두 배로 만듭니다.",
+          "how": "하나의 shape로 합치거나 precomp로 재사용하세요."
+        },
+        "excessiveKeyframes": {
+          "title": "과도한 키프레임",
+          "metric": "{value}개 키프레임",
+          "what": "일부 레이어의 키프레임 밀도가 매우 높습니다.",
+          "why": "키프레임 배열이 커지면 JSON 용량과 저사양 기기의 CPU 사용이 함께 증가합니다.",
+          "how": "애니메이션 커브를 단순화하거나 불필요한 키프레임을 제거하세요. 낮은 샘플링으로 다시 베이크하는 것도 방법입니다."
+        },
+        "largeImageResize": {
+          "title": "해상도가 과한 이미지 에셋",
+          "metric": "{value}개 에셋",
+          "what": "컴포지션보다 훨씬 큰 이미지 에셋이 포함되어 있습니다.",
+          "why": "2배 이상의 이미지는 매 렌더마다 대역폭과 메모리를 낭비합니다.",
+          "how": "임포트 전에 렌더 크기의 최대 2배 이하로 PNG/JPG를 리사이즈하세요."
+        },
+        "missingMarkers": {
+          "title": "마커가 없음",
+          "metric": "",
+          "what": "애니메이션에 명명된 마커가 전혀 없습니다.",
+          "why": "마커가 없으면 개발자가 프레임 번호를 추측해 세그먼트를 재생해야 합니다.",
+          "how": "After Effects에서 intro/loop/outro 등 의미 있는 구간마다 마커를 추가하세요."
+        }
+      }
+    },
+    "compatibility": {
+      "title": "플랫폼 호환성",
+      "subtitle": "Web / iOS / Android Lottie 런타임에서의 동작 지원 수준",
+      "officialDoc": "Airbnb 공식 문서 →",
+      "platforms": {
+        "web": "Web",
+        "ios": "iOS",
+        "android": "Android"
+      },
+      "levels": {
+        "supported": "완전 지원",
+        "partial": "부분 지원",
+        "unsupported": "미지원"
+      },
+      "issueBreakdown": "미지원 {unsupported}건 · 부분 지원 {partial}건",
+      "detectedIssues": "{platform}에서 감지된 이슈",
+      "noIssues": "이 파일에서 플랫폼 이슈가 감지되지 않았습니다.",
+      "columnFeature": "기능",
+      "columnDetected": "파일 내 사용",
+      "yes": "예",
+      "no": "아니오"
+    }
+  },
   "common": {
     "backToHome": "← 홈으로 돌아가기",
     "backToBlog": "← 블로그로 돌아가기",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^4.1.4",
         "critters": "^0.0.25",
         "eslint": "^9",
         "eslint-config-next": "^15.5.12",
         "tailwindcss": "^4",
         "typescript": "5.9.3",
+        "vitest": "^4.1.4",
         "webpack-bundle-analyzer": "^4.10.2"
       }
     },
@@ -41,6 +43,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -50,10 +112,33 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -769,6 +854,53 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.12",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
@@ -958,6 +1090,16 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -1289,6 +1431,270 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1305,6 +1711,13 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
@@ -1713,6 +2126,35 @@
         "tailwindcss": "4.0.12"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2040,6 +2482,123 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2268,11 +2827,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2426,6 +3014,16 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2479,6 +3077,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/critters": {
       "version": "0.0.25",
@@ -2907,6 +3512,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3372,6 +3984,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3379,6 +4001,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4267,6 +4899,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4397,10 +5068,11 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
-      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -4412,26 +5084,49 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.2",
-        "lightningcss-darwin-x64": "1.29.2",
-        "lightningcss-freebsd-x64": "1.29.2",
-        "lightningcss-linux-arm-gnueabihf": "1.29.2",
-        "lightningcss-linux-arm64-gnu": "1.29.2",
-        "lightningcss-linux-arm64-musl": "1.29.2",
-        "lightningcss-linux-x64-gnu": "1.29.2",
-        "lightningcss-linux-x64-musl": "1.29.2",
-        "lightningcss-win32-arm64-msvc": "1.29.2",
-        "lightningcss-win32-x64-msvc": "1.29.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
-      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -4445,13 +5140,14 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
-      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -4465,13 +5161,14 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
-      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -4485,13 +5182,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
-      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4505,13 +5203,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
-      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4525,13 +5224,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
-      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4545,13 +5245,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
-      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4565,13 +5266,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
-      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4585,13 +5287,14 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
-      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -4605,13 +5308,14 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
-      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -4661,6 +5365,44 @@
       "version": "5.12.2",
       "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.12.2.tgz",
       "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4732,15 +5474,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
-      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5061,6 +5804,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -5170,6 +5924,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5236,9 +5997,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -5254,8 +6015,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5433,6 +6195,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/run-parallel": {
@@ -5713,6 +6509,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -5740,6 +6543,20 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
       "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -5930,6 +6747,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5976,6 +6810,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6184,6 +7028,229 @@
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
@@ -6308,6 +7375,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "playwright test",
-    "test:headed": "playwright test --headed"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "lottie-web": "^5.12.2",
@@ -24,11 +26,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.4",
     "critters": "^0.0.25",
     "eslint": "^9",
     "eslint-config-next": "^15.5.12",
     "tailwindcss": "^4",
     "typescript": "5.9.3",
+    "vitest": "^4.1.4",
     "webpack-bundle-analyzer": "^4.10.2"
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,12 +4,10 @@ import { useState, useEffect, useRef, Suspense } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import type { AnimationItem, LottiePlayer } from "lottie-web";
+import { AnalysisResult } from "@/components/analysis/AnalysisResult";
+import type { LottieJson } from "@/lib/lottie-analyzer";
 
-interface AnimationData {
-  w?: number;
-  h?: number;
-  [key: string]: unknown;
-}
+type AnimationData = LottieJson;
 
 function LoadingFallback() {
   const t = useTranslations("common");
@@ -75,6 +73,7 @@ export default function Home() {
   }>({ width: 0, height: 0 });
 
   const [fileName, setFileName] = useState<string | null>(null);
+  const [fileSizeBytes, setFileSizeBytes] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -100,45 +99,33 @@ export default function Home() {
     };
   }, []);
 
+  const loadFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const result = e.target?.result as string;
+        if (result) {
+          const parsedData = JSON.parse(result) as AnimationData;
+          setAnimationData(parsedData);
+          setFileName(file.name);
+          setFileSizeBytes(file.size);
+        }
+      } catch (error) {
+        console.error("Invalid JSON file", error);
+      }
+    };
+    reader.readAsText(file);
+  };
+
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const result = e.target?.result as string;
-          if (result) {
-            const parsedData = JSON.parse(result) as AnimationData;
-            setAnimationData(parsedData);
-            setFileName(file.name);
-          }
-        } catch (error) {
-          console.error("Invalid JSON file", error);
-        }
-      };
-      reader.readAsText(file);
-    }
+    if (file) loadFile(file);
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     const file = event.dataTransfer.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const result = e.target?.result as string;
-          if (result) {
-            const parsedData = JSON.parse(result) as AnimationData;
-            setAnimationData(parsedData);
-            setFileName(file.name);
-          }
-        } catch (error) {
-          console.error("Invalid JSON file", error);
-        }
-      };
-      reader.readAsText(file);
-    }
+    if (file) loadFile(file);
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -212,6 +199,12 @@ export default function Home() {
           </p>
         </div>
       </section>
+
+      {animationData ? (
+        <section className="w-full max-w-5xl mx-auto px-6 pb-16">
+          <AnalysisResult data={animationData} fileSizeBytes={fileSizeBytes} />
+        </section>
+      ) : null}
 
       <section className="w-full max-w-5xl mx-auto px-6 py-16">
         <h2 className="text-3xl font-bold text-white text-center mb-12">

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,72 +1,31 @@
 "use client";
 
-import { useState, useEffect, useRef, Suspense } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
-import type { AnimationItem, LottiePlayer } from "lottie-web";
+import type { LottiePlayer } from "lottie-web";
 import { AnalysisResult } from "@/components/analysis/AnalysisResult";
+import { BackgroundSection } from "@/components/player/BackgroundSection";
+import {
+  LottiePlayerStage,
+  type LottiePlayerHandle,
+} from "@/components/player/LottiePlayerStage";
+import { PlayerControlsSection } from "@/components/player/PlayerControlsSection";
+import type { PlayerState } from "@/components/player/types";
 import type { LottieJson } from "@/lib/lottie-analyzer";
 
-type AnimationData = LottieJson;
-
-function LoadingFallback() {
-  const t = useTranslations("common");
-  return (
-    <div className="flex items-center justify-center w-full h-96 bg-gray-800 rounded-lg">
-      <div className="animate-pulse text-gray-400">{t("loading")}</div>
-    </div>
-  );
-}
-
-function AnimationContainer({
-  lottie,
-  animationData,
-  containerRef,
-  setAnimationSize,
-}: {
-  lottie: LottiePlayer | null;
-  animationData: AnimationData | null;
-  containerRef: React.RefObject<HTMLDivElement>;
-  setAnimationSize: (size: { width: number; height: number }) => void;
-}) {
-  const animationRef = useRef<AnimationItem | null>(null);
-
-  useEffect(() => {
-    if (lottie && animationData && containerRef.current) {
-      if (animationRef.current) {
-        animationRef.current.destroy();
-      }
-
-      containerRef.current.innerHTML = "";
-      animationRef.current = lottie.loadAnimation({
-        container: containerRef.current,
-        renderer: "svg",
-        loop: true,
-        autoplay: true,
-        animationData,
-      });
-
-      if (animationData.w && animationData.h) {
-        setAnimationSize({ width: animationData.w, height: animationData.h });
-      }
-
-      return () => {
-        if (animationRef.current) {
-          animationRef.current.destroy();
-        }
-      };
-    }
-  }, [lottie, animationData, containerRef, setAnimationSize]);
-
-  return null;
-}
+const DEFAULT_PLAYER_STATE: PlayerState = {
+  speed: 1,
+  direction: 1,
+  loopMode: "loop",
+  segment: null,
+  background: { kind: "transparent" },
+};
 
 export default function Home() {
   const t = useTranslations("home");
   const [lottie, setLottie] = useState<LottiePlayer | null>(null);
-  const [animationData, setAnimationData] = useState<AnimationData | null>(
-    null
-  );
+  const [animationData, setAnimationData] = useState<LottieJson | null>(null);
   const [animationSize, setAnimationSize] = useState<{
     width: number;
     height: number;
@@ -74,8 +33,16 @@ export default function Home() {
 
   const [fileName, setFileName] = useState<string | null>(null);
   const [fileSizeBytes, setFileSizeBytes] = useState<number | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [playerState, setPlayerState] =
+    useState<PlayerState>(DEFAULT_PLAYER_STATE);
+  const [currentFrame, setCurrentFrame] = useState(0);
+  const [totalFrames, setTotalFrames] = useState(0);
+  const [frameRate, setFrameRate] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const playerHandleRef = useRef<LottiePlayerHandle | null>(null);
+  const dropZoneRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const loadLottie = async () => {
@@ -88,16 +55,13 @@ export default function Home() {
     };
 
     loadLottie();
-
-    const updateViewportSize = () => {};
-
-    updateViewportSize();
-    window.addEventListener("resize", updateViewportSize);
-
-    return () => {
-      window.removeEventListener("resize", updateViewportSize);
-    };
   }, []);
+
+  useEffect(() => {
+    if (animationData?.w && animationData?.h) {
+      setAnimationSize({ width: animationData.w, height: animationData.h });
+    }
+  }, [animationData]);
 
   const loadFile = (file: File) => {
     const reader = new FileReader();
@@ -105,10 +69,12 @@ export default function Home() {
       try {
         const result = e.target?.result as string;
         if (result) {
-          const parsedData = JSON.parse(result) as AnimationData;
+          const parsedData = JSON.parse(result) as LottieJson;
           setAnimationData(parsedData);
           setFileName(file.name);
           setFileSizeBytes(file.size);
+          setPlayerState(DEFAULT_PLAYER_STATE);
+          setCurrentFrame(0);
         }
       } catch (error) {
         console.error("Invalid JSON file", error);
@@ -138,6 +104,10 @@ export default function Home() {
     }
   };
 
+  const updatePlayerState = (partial: Partial<PlayerState>) => {
+    setPlayerState((prev) => ({ ...prev, ...partial }));
+  };
+
   return (
     <div className="flex flex-col items-center bg-gray-900">
       <section className="flex flex-col items-center justify-center min-h-screen p-6 w-full">
@@ -150,7 +120,7 @@ export default function Home() {
         <p className="text-[12px] md:text-[14px] lg:text-[16px] text-gray-400 mb-6 text-center">
           {t("privacyNote")}
         </p>
-      <label className="mb-4 w-fit text-center">
+        <label className="mb-4 w-fit text-center">
           {fileName && (
             <span className="mt-2 mr-2 text-gray-200">{fileName}</span>
           )}
@@ -170,28 +140,35 @@ export default function Home() {
             <span className="absolute inset-0 w-full h-full border-2 border-transparent rounded-lg animate-pulse"></span>
           </button>
         </label>
-        <div
-          ref={containerRef}
-          className="border border-gray-700 w-full max-w-md h-96 flex items-center justify-center mb-8 bg-gray-800 rounded-lg shadow-lg"
-          onDrop={handleDrop}
-          onDragOver={handleDragOver}
-          aria-label={t("dropHere")}
-          role="region"
-        >
-          {!animationData && (
+
+        {!animationData ? (
+          <div
+            ref={dropZoneRef}
+            className="border border-gray-700 w-full max-w-md h-96 flex items-center justify-center mb-8 bg-gray-800 rounded-lg shadow-lg"
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            aria-label={t("dropHere")}
+            role="region"
+          >
             <p className="text-gray-400">{t("dropHere")}</p>
-          )}
-        </div>
-        {lottie && animationData && (
-          <Suspense fallback={<LoadingFallback />}>
-            <AnimationContainer
+          </div>
+        ) : lottie ? (
+          <div className="w-full max-w-md">
+            <LottiePlayerStage
               lottie={lottie}
-              animationData={animationData}
-              containerRef={containerRef as React.RefObject<HTMLDivElement>}
-              setAnimationSize={setAnimationSize}
+              data={animationData}
+              state={playerState}
+              onFrame={setCurrentFrame}
+              onReady={(total, fr) => {
+                setTotalFrames(total);
+                setFrameRate(fr);
+              }}
+              onPlayStateChange={setIsPlaying}
+              handleRef={playerHandleRef}
             />
-          </Suspense>
-        )}
+          </div>
+        ) : null}
+
         <div className="mt-4">
           <p className="animation-size text-gray-300">
             {t("animationSize")} {animationSize.width} x{" "}
@@ -200,9 +177,30 @@ export default function Home() {
         </div>
       </section>
 
-      {animationData ? (
+      {animationData && fileName ? (
         <section className="w-full max-w-5xl mx-auto px-6 pb-16">
-          <AnalysisResult data={animationData} fileSizeBytes={fileSizeBytes} />
+          <div className="flex flex-col gap-4">
+            <PlayerControlsSection
+              state={playerState}
+              onChange={updatePlayerState}
+              playerHandle={playerHandleRef}
+              currentFrame={currentFrame}
+              totalFrames={totalFrames}
+              frameRate={frameRate}
+              isPlaying={isPlaying}
+            />
+            <BackgroundSection
+              value={playerState.background}
+              onChange={(background) => updatePlayerState({ background })}
+            />
+          </div>
+          <div className="mt-4">
+            <AnalysisResult
+              data={animationData}
+              fileSizeBytes={fileSizeBytes}
+              fileName={fileName}
+            />
+          </div>
         </section>
       ) : null}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,8 +3,12 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --surface: #111827;
+  --surface-strong: #1f2937;
+  --muted: #9ca3af;
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -12,13 +16,6 @@
   --color-foreground: var(--foreground);
   --font-sans: "Inter", sans-serif;
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/components/analysis/AnalysisResult.tsx
+++ b/src/components/analysis/AnalysisResult.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { analyzeLottie, type LottieJson } from "@/lib/lottie-analyzer";
+import { CompatibilitySection } from "./CompatibilitySection";
+import { LayersSection } from "./LayersSection";
+import { MetadataSection } from "./MetadataSection";
+import { OptimizationSection } from "./OptimizationSection";
+import { PerformanceSection } from "./PerformanceSection";
+
+interface AnalysisResultProps {
+  data: LottieJson;
+  fileSizeBytes: number | null;
+}
+
+export function AnalysisResult({ data, fileSizeBytes }: AnalysisResultProps) {
+  const [highlightedLayerIndex, setHighlightedLayerIndex] = useState<number | null>(
+    null,
+  );
+
+  const analysis = useMemo(
+    () => analyzeLottie(data, { fileSizeBytes }),
+    [data, fileSizeBytes],
+  );
+
+  const handleJumpToLayer = (layerIndex: number) => {
+    setHighlightedLayerIndex(layerIndex);
+    if (typeof window !== "undefined") {
+      const target = document.getElementById("analysis-layers");
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <MetadataSection metadata={analysis.metadata} />
+      <PerformanceSection score={analysis.performance} />
+      <OptimizationSection
+        suggestions={analysis.suggestions}
+        onJumpToLayer={handleJumpToLayer}
+      />
+      <LayersSection
+        data={analysis.layers}
+        highlightedLayerIndex={highlightedLayerIndex}
+        onClearHighlight={() => setHighlightedLayerIndex(null)}
+      />
+      <CompatibilitySection
+        compatibility={analysis.compatibility}
+        onJumpToLayer={handleJumpToLayer}
+      />
+    </div>
+  );
+}

--- a/src/components/analysis/AnalysisResult.tsx
+++ b/src/components/analysis/AnalysisResult.tsx
@@ -7,13 +7,15 @@ import { LayersSection } from "./LayersSection";
 import { MetadataSection } from "./MetadataSection";
 import { OptimizationSection } from "./OptimizationSection";
 import { PerformanceSection } from "./PerformanceSection";
+import { SnippetSection } from "./SnippetSection";
 
 interface AnalysisResultProps {
   data: LottieJson;
   fileSizeBytes: number | null;
+  fileName: string;
 }
 
-export function AnalysisResult({ data, fileSizeBytes }: AnalysisResultProps) {
+export function AnalysisResult({ data, fileSizeBytes, fileName }: AnalysisResultProps) {
   const [highlightedLayerIndex, setHighlightedLayerIndex] = useState<number | null>(
     null,
   );
@@ -49,6 +51,11 @@ export function AnalysisResult({ data, fileSizeBytes }: AnalysisResultProps) {
       <CompatibilitySection
         compatibility={analysis.compatibility}
         onJumpToLayer={handleJumpToLayer}
+      />
+      <SnippetSection
+        fileName={fileName}
+        width={analysis.metadata.width}
+        height={analysis.metadata.height}
       />
     </div>
   );

--- a/src/components/analysis/CompatibilitySection.tsx
+++ b/src/components/analysis/CompatibilitySection.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslations } from "next-intl";
 import type {
   PlatformCompatibility,
+  PlatformFeatureSupport,
   PlatformKey,
   PlatformSupportLevel,
 } from "@/lib/lottie-analyzer";
 import { SectionCard } from "./SectionCard";
+
+type TranslateFn = ReturnType<typeof useTranslations>;
 
 interface CompatibilitySectionProps {
   compatibility: PlatformCompatibility;
@@ -48,6 +51,7 @@ export function CompatibilitySection({
 }: CompatibilitySectionProps) {
   const t = useTranslations("analysis.compatibility");
   const [expanded, setExpanded] = useState<PlatformKey | null>(null);
+  const detailPanelId = useId();
 
   const detected = compatibility.features.filter((f) => f.detectedInFile);
 
@@ -79,6 +83,7 @@ export function CompatibilitySection({
               onClick={() => setExpanded(isOpen ? null : platform)}
               className={`flex flex-col items-start rounded-lg p-4 text-left ring-1 ${style.bg} ${style.ring}`}
               aria-expanded={isOpen}
+              aria-controls={detailPanelId}
             >
               <div className="flex w-full items-center justify-between">
                 <span className="text-sm font-semibold text-white">
@@ -103,63 +108,16 @@ export function CompatibilitySection({
       </div>
 
       {expanded ? (
-        <div className="mt-4 rounded-md border border-gray-700 bg-gray-900/40 p-4">
-          <h4 className="mb-2 text-sm font-semibold text-white">
-            {t("detectedIssues", { platform: t(`platforms.${expanded}`) })}
-          </h4>
-          {detected.length === 0 ? (
-            <p className="text-xs text-gray-400">{t("noIssues")}</p>
-          ) : (
-            <ul className="space-y-2">
-              {detected
-                .filter((f) => f[expanded!] !== "supported")
-                .map((f) => {
-                  const level = f[expanded!];
-                  const style = LEVEL_STYLES[level];
-                  return (
-                    <li
-                      key={f.feature}
-                      className="flex flex-wrap items-center gap-3 rounded border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm"
-                    >
-                      <span className={`font-semibold ${style.text}`}>
-                        {style.icon}
-                      </span>
-                      <span className="text-gray-200">{f.feature}</span>
-                      <span className="ml-auto text-xs text-gray-400">
-                        {t(`levels.${level}`)}
-                      </span>
-                      {f.relatedLayerIndexes.length > 0 ? (
-                        <div className="flex w-full flex-wrap gap-1 pt-1">
-                          {f.relatedLayerIndexes.slice(0, 6).map((idx) => (
-                            <button
-                              key={idx}
-                              type="button"
-                              onClick={() => onJumpToLayer(idx)}
-                              className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[10px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
-                            >
-                              #{idx}
-                            </button>
-                          ))}
-                          {f.relatedLayerIndexes.length > 6 ? (
-                            <span className="text-[10px] text-gray-500">
-                              +{f.relatedLayerIndexes.length - 6}
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              {detected.filter((f) => f[expanded!] !== "supported").length ===
-              0 ? (
-                <p className="text-xs text-gray-400">{t("noIssues")}</p>
-              ) : null}
-            </ul>
-          )}
-        </div>
+        <CompatibilityPlatformDetail
+          panelId={detailPanelId}
+          platform={expanded}
+          features={detected}
+          onJumpToLayer={onJumpToLayer}
+          t={t}
+        />
       ) : null}
 
-      <div className="mt-5 overflow-hidden rounded-md border border-gray-800">
+      <div className="mt-5 overflow-x-auto rounded-md border border-gray-800">
         <table className="min-w-full text-left text-sm">
           <thead className="bg-gray-900/80 text-xs uppercase tracking-wide text-gray-400">
             <tr>
@@ -200,5 +158,77 @@ export function CompatibilitySection({
         </table>
       </div>
     </SectionCard>
+  );
+}
+
+interface CompatibilityPlatformDetailProps {
+  panelId: string;
+  platform: PlatformKey;
+  features: PlatformFeatureSupport[];
+  onJumpToLayer: (layerIndex: number) => void;
+  t: TranslateFn;
+}
+
+function CompatibilityPlatformDetail({
+  panelId,
+  platform,
+  features,
+  onJumpToLayer,
+  t,
+}: CompatibilityPlatformDetailProps) {
+  const issues = features.filter((f) => f[platform] !== "supported");
+
+  return (
+    <div
+      id={panelId}
+      className="mt-4 rounded-md border border-gray-700 bg-gray-900/40 p-4"
+    >
+      <h4 className="mb-2 text-sm font-semibold text-white">
+        {t("detectedIssues", { platform: t(`platforms.${platform}`) })}
+      </h4>
+      {issues.length === 0 ? (
+        <p className="text-xs text-gray-400">{t("noIssues")}</p>
+      ) : (
+        <ul className="space-y-2">
+          {issues.map((f) => {
+            const level = f[platform];
+            const style = LEVEL_STYLES[level];
+            return (
+              <li
+                key={f.feature}
+                className="flex flex-wrap items-center gap-3 rounded border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm"
+              >
+                <span className={`font-semibold ${style.text}`}>
+                  {style.icon}
+                </span>
+                <span className="text-gray-200">{f.feature}</span>
+                <span className="ml-auto text-xs text-gray-400">
+                  {t(`levels.${level}`)}
+                </span>
+                {f.relatedLayerIndexes.length > 0 ? (
+                  <div className="flex w-full flex-wrap gap-1 pt-1">
+                    {f.relatedLayerIndexes.slice(0, 6).map((idx) => (
+                      <button
+                        key={idx}
+                        type="button"
+                        onClick={() => onJumpToLayer(idx)}
+                        className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[10px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
+                      >
+                        #{idx}
+                      </button>
+                    ))}
+                    {f.relatedLayerIndexes.length > 6 ? (
+                      <span className="text-[10px] text-gray-500">
+                        +{f.relatedLayerIndexes.length - 6}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/src/components/analysis/CompatibilitySection.tsx
+++ b/src/components/analysis/CompatibilitySection.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import type {
+  PlatformCompatibility,
+  PlatformKey,
+  PlatformSupportLevel,
+} from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface CompatibilitySectionProps {
+  compatibility: PlatformCompatibility;
+  onJumpToLayer: (layerIndex: number) => void;
+}
+
+const PLATFORMS: PlatformKey[] = ["web", "ios", "android"];
+
+const LEVEL_STYLES: Record<
+  PlatformSupportLevel,
+  { icon: string; text: string; bg: string; ring: string }
+> = {
+  supported: {
+    icon: "✓",
+    text: "text-emerald-300",
+    bg: "bg-emerald-500/10",
+    ring: "ring-emerald-500/40",
+  },
+  partial: {
+    icon: "!",
+    text: "text-amber-300",
+    bg: "bg-amber-500/10",
+    ring: "ring-amber-500/40",
+  },
+  unsupported: {
+    icon: "✗",
+    text: "text-rose-300",
+    bg: "bg-rose-500/10",
+    ring: "ring-rose-500/40",
+  },
+};
+
+const AIRBNB_DOC_URL = "https://airbnb.io/lottie/#/supported-features";
+
+export function CompatibilitySection({
+  compatibility,
+  onJumpToLayer,
+}: CompatibilitySectionProps) {
+  const t = useTranslations("analysis.compatibility");
+  const [expanded, setExpanded] = useState<PlatformKey | null>(null);
+
+  const detected = compatibility.features.filter((f) => f.detectedInFile);
+
+  return (
+    <SectionCard
+      id="analysis-compatibility"
+      title={t("title")}
+      subtitle={t("subtitle")}
+      actions={
+        <a
+          href={AIRBNB_DOC_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-xs text-sky-300 hover:underline"
+        >
+          {t("officialDoc")}
+        </a>
+      }
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
+        {PLATFORMS.map((platform) => {
+          const summary = compatibility.summary[platform];
+          const style = LEVEL_STYLES[summary.overall];
+          const isOpen = expanded === platform;
+          return (
+            <button
+              key={platform}
+              type="button"
+              onClick={() => setExpanded(isOpen ? null : platform)}
+              className={`flex flex-col items-start rounded-lg p-4 text-left ring-1 ${style.bg} ${style.ring}`}
+              aria-expanded={isOpen}
+            >
+              <div className="flex w-full items-center justify-between">
+                <span className="text-sm font-semibold text-white">
+                  {t(`platforms.${platform}`)}
+                </span>
+                <span className={`text-2xl font-black ${style.text}`}>
+                  {style.icon}
+                </span>
+              </div>
+              <span className={`mt-2 text-xs ${style.text}`}>
+                {t(`levels.${summary.overall}`)}
+              </span>
+              <span className="mt-1 text-[11px] text-gray-400">
+                {t("issueBreakdown", {
+                  unsupported: summary.unsupportedCount,
+                  partial: summary.partialCount,
+                })}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {expanded ? (
+        <div className="mt-4 rounded-md border border-gray-700 bg-gray-900/40 p-4">
+          <h4 className="mb-2 text-sm font-semibold text-white">
+            {t("detectedIssues", { platform: t(`platforms.${expanded}`) })}
+          </h4>
+          {detected.length === 0 ? (
+            <p className="text-xs text-gray-400">{t("noIssues")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {detected
+                .filter((f) => f[expanded!] !== "supported")
+                .map((f) => {
+                  const level = f[expanded!];
+                  const style = LEVEL_STYLES[level];
+                  return (
+                    <li
+                      key={f.feature}
+                      className="flex flex-wrap items-center gap-3 rounded border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm"
+                    >
+                      <span className={`font-semibold ${style.text}`}>
+                        {style.icon}
+                      </span>
+                      <span className="text-gray-200">{f.feature}</span>
+                      <span className="ml-auto text-xs text-gray-400">
+                        {t(`levels.${level}`)}
+                      </span>
+                      {f.relatedLayerIndexes.length > 0 ? (
+                        <div className="flex w-full flex-wrap gap-1 pt-1">
+                          {f.relatedLayerIndexes.slice(0, 6).map((idx) => (
+                            <button
+                              key={idx}
+                              type="button"
+                              onClick={() => onJumpToLayer(idx)}
+                              className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[10px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
+                            >
+                              #{idx}
+                            </button>
+                          ))}
+                          {f.relatedLayerIndexes.length > 6 ? (
+                            <span className="text-[10px] text-gray-500">
+                              +{f.relatedLayerIndexes.length - 6}
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              {detected.filter((f) => f[expanded!] !== "supported").length ===
+              0 ? (
+                <p className="text-xs text-gray-400">{t("noIssues")}</p>
+              ) : null}
+            </ul>
+          )}
+        </div>
+      ) : null}
+
+      <div className="mt-5 overflow-hidden rounded-md border border-gray-800">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-gray-900/80 text-xs uppercase tracking-wide text-gray-400">
+            <tr>
+              <th className="px-3 py-2">{t("columnFeature")}</th>
+              {PLATFORMS.map((platform) => (
+                <th key={platform} className="px-3 py-2 text-center">
+                  {t(`platforms.${platform}`)}
+                </th>
+              ))}
+              <th className="px-3 py-2 text-center">{t("columnDetected")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {compatibility.features.map((f) => (
+              <tr
+                key={f.feature}
+                className="border-t border-gray-800 text-sm text-gray-200"
+              >
+                <td className="px-3 py-2">{f.feature}</td>
+                {PLATFORMS.map((platform) => {
+                  const level = f[platform];
+                  const style = LEVEL_STYLES[level];
+                  return (
+                    <td
+                      key={platform}
+                      className={`px-3 py-2 text-center font-semibold ${style.text}`}
+                    >
+                      {style.icon}
+                    </td>
+                  );
+                })}
+                <td className="px-3 py-2 text-center text-xs text-gray-400">
+                  {f.detectedInFile ? t("yes") : t("no")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/LayersSection.tsx
+++ b/src/components/analysis/LayersSection.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  getBlendModeName,
+  type AnalyzedLayer,
+  type LayerAnalysisResult,
+  type LayerTreeNode,
+} from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface LayersSectionProps {
+  data: LayerAnalysisResult;
+  highlightedLayerIndex: number | null;
+  onClearHighlight: () => void;
+}
+
+const TYPE_BADGE_CLASSES: Record<string, string> = {
+  Shape: "bg-emerald-500/20 text-emerald-300 border-emerald-500/40",
+  Image: "bg-sky-500/20 text-sky-300 border-sky-500/40",
+  Text: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+  Precomp: "bg-fuchsia-500/20 text-fuchsia-300 border-fuchsia-500/40",
+  Solid: "bg-rose-500/20 text-rose-300 border-rose-500/40",
+  Null: "bg-gray-500/20 text-gray-300 border-gray-500/40",
+  Audio: "bg-indigo-500/20 text-indigo-300 border-indigo-500/40",
+};
+
+function typeBadgeClass(typeName: string): string {
+  return (
+    TYPE_BADGE_CLASSES[typeName] ??
+    "bg-gray-700/60 text-gray-200 border-gray-600"
+  );
+}
+
+const PAGE_SIZE = 50;
+
+interface LayerRowProps {
+  layer: AnalyzedLayer;
+  highlighted: boolean;
+  registerRef: (idx: number, el: HTMLTableRowElement | null) => void;
+}
+
+function LayerRow({ layer, highlighted, registerRef }: LayerRowProps) {
+  return (
+    <tr
+      ref={(el) => registerRef(layer.index, el)}
+      className={`border-t border-gray-800 text-sm transition-colors ${
+        highlighted ? "bg-yellow-500/10" : "hover:bg-gray-800/40"
+      }`}
+    >
+      <td className="px-3 py-2 text-gray-400">{layer.index}</td>
+      <td className="px-3 py-2 text-white">
+        <div className="flex items-center gap-2">
+          <span>{layer.name}</span>
+          {layer.isHidden ? (
+            <span className="rounded bg-red-500/20 px-2 py-0.5 text-[10px] uppercase text-red-300">
+              hidden
+            </span>
+          ) : null}
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <span
+          className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium ${typeBadgeClass(
+            layer.typeName,
+          )}`}
+        >
+          {layer.typeName}
+        </span>
+      </td>
+      <td className="px-3 py-2 text-right font-mono text-xs text-gray-300">
+        {layer.startFrame} – {layer.endFrame}
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-300">
+        {getBlendModeName(layer.blendMode)}
+      </td>
+      <td className="px-3 py-2 text-center text-xs text-gray-300">
+        {layer.is3D ? "3D" : "—"}
+      </td>
+      <td className="px-3 py-2 text-right text-xs text-gray-300">
+        {layer.effectCount}
+      </td>
+      <td className="px-3 py-2 text-right text-xs text-gray-300">
+        {layer.maskCount}
+      </td>
+    </tr>
+  );
+}
+
+interface TreeNodeRowProps {
+  node: LayerTreeNode;
+  depth: number;
+  highlightedLayerIndex: number | null;
+}
+
+function TreeNodeRow({ node, depth, highlightedLayerIndex }: TreeNodeRowProps) {
+  const isHighlighted = highlightedLayerIndex === node.index;
+  return (
+    <li>
+      <div
+        className={`flex items-center gap-2 rounded px-2 py-1 text-sm ${
+          isHighlighted ? "bg-yellow-500/10 text-yellow-200" : "text-gray-200"
+        }`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        <span
+          className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${typeBadgeClass(
+            node.typeName,
+          )}`}
+        >
+          {node.typeName}
+        </span>
+        <span>{node.name}</span>
+        <span className="ml-auto font-mono text-[11px] text-gray-500">
+          #{node.index}
+        </span>
+      </div>
+      {node.children.length > 0 ? (
+        <ul>
+          {node.children.map((child) => (
+            <TreeNodeRow
+              key={child.index}
+              node={child}
+              depth={depth + 1}
+              highlightedLayerIndex={highlightedLayerIndex}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+export function LayersSection({
+  data,
+  highlightedLayerIndex,
+  onClearHighlight,
+}: LayersSectionProps) {
+  const t = useTranslations("analysis.layers");
+  const [mode, setMode] = useState<"list" | "tree">("list");
+  const [page, setPage] = useState(0);
+  const rowRefs = useRef(new Map<number, HTMLTableRowElement>());
+
+  const totalPages = Math.max(1, Math.ceil(data.layers.length / PAGE_SIZE));
+  const visibleLayers = useMemo(
+    () => data.layers.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [data.layers, page],
+  );
+
+  useEffect(() => {
+    if (highlightedLayerIndex === null) return;
+    if (mode !== "list") setMode("list");
+    const targetIdx = data.layers.findIndex(
+      (l) => l.index === highlightedLayerIndex,
+    );
+    if (targetIdx < 0) return;
+    const targetPage = Math.floor(targetIdx / PAGE_SIZE);
+    if (targetPage !== page) setPage(targetPage);
+  }, [highlightedLayerIndex, data.layers, mode, page]);
+
+  useEffect(() => {
+    if (highlightedLayerIndex === null) return;
+    const el = rowRefs.current.get(highlightedLayerIndex);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [highlightedLayerIndex, page, mode]);
+
+  const registerRef = (idx: number, el: HTMLTableRowElement | null) => {
+    if (el) rowRefs.current.set(idx, el);
+    else rowRefs.current.delete(idx);
+  };
+
+  return (
+    <SectionCard
+      id="analysis-layers"
+      title={t("title")}
+      subtitle={t("subtitle", { count: data.layers.length })}
+      actions={
+        <div className="flex gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5 text-xs">
+          <button
+            type="button"
+            onClick={() => setMode("list")}
+            className={`rounded px-2 py-1 ${
+              mode === "list"
+                ? "bg-gray-700 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t("listMode")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("tree")}
+            className={`rounded px-2 py-1 ${
+              mode === "tree"
+                ? "bg-gray-700 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t("treeMode")}
+          </button>
+        </div>
+      }
+    >
+      {data.layers.length === 0 ? (
+        <p className="text-sm text-gray-400">{t("empty")}</p>
+      ) : mode === "list" ? (
+        <>
+          <div className="max-h-[480px] overflow-auto rounded-md border border-gray-800">
+            <table className="min-w-full divide-y divide-gray-800 text-left">
+              <thead className="bg-gray-900/80 text-xs uppercase tracking-wide text-gray-400">
+                <tr>
+                  <th className="px-3 py-2">#</th>
+                  <th className="px-3 py-2">{t("columnName")}</th>
+                  <th className="px-3 py-2">{t("columnType")}</th>
+                  <th className="px-3 py-2 text-right">{t("columnFrames")}</th>
+                  <th className="px-3 py-2">{t("columnBlend")}</th>
+                  <th className="px-3 py-2 text-center">{t("column3D")}</th>
+                  <th className="px-3 py-2 text-right">{t("columnEffects")}</th>
+                  <th className="px-3 py-2 text-right">{t("columnMasks")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleLayers.map((layer) => (
+                  <LayerRow
+                    key={layer.index}
+                    layer={layer}
+                    highlighted={highlightedLayerIndex === layer.index}
+                    registerRef={registerRef}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 ? (
+            <div className="mt-3 flex items-center justify-between text-xs text-gray-400">
+              <span>
+                {t("pageStatus", {
+                  from: page * PAGE_SIZE + 1,
+                  to: Math.min((page + 1) * PAGE_SIZE, data.layers.length),
+                  total: data.layers.length,
+                })}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="rounded border border-gray-700 px-2 py-1 disabled:opacity-40"
+                >
+                  {t("prev")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setPage((p) => Math.min(totalPages - 1, p + 1))
+                  }
+                  disabled={page >= totalPages - 1}
+                  className="rounded border border-gray-700 px-2 py-1 disabled:opacity-40"
+                >
+                  {t("next")}
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <ul className="max-h-[480px] overflow-auto rounded-md border border-gray-800 bg-gray-900/40 p-2">
+          {data.tree.map((node) => (
+            <TreeNodeRow
+              key={node.index}
+              node={node}
+              depth={0}
+              highlightedLayerIndex={highlightedLayerIndex}
+            />
+          ))}
+        </ul>
+      )}
+
+      {highlightedLayerIndex !== null ? (
+        <button
+          type="button"
+          onClick={onClearHighlight}
+          className="mt-3 rounded border border-gray-700 px-3 py-1 text-xs text-gray-300 hover:bg-gray-800"
+        >
+          {t("clearHighlight")}
+        </button>
+      ) : null}
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/MetadataSection.tsx
+++ b/src/components/analysis/MetadataSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { formatDuration, formatFileSize } from "@/lib/lottie-analyzer";
+import type { LottieMetadata } from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface MetadataSectionProps {
+  metadata: LottieMetadata;
+}
+
+function MetricTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-md border border-gray-700 bg-gray-900/50 p-4">
+      <div className="text-xs uppercase tracking-wide text-gray-400">
+        {label}
+      </div>
+      <div className="mt-2 text-xl font-semibold text-white break-words">
+        {value}
+      </div>
+      {hint ? <div className="mt-1 text-xs text-gray-500">{hint}</div> : null}
+    </div>
+  );
+}
+
+export function MetadataSection({ metadata }: MetadataSectionProps) {
+  const t = useTranslations("analysis.metadata");
+  const layerTypes = ["Shape", "Image", "Text", "Precomp", "Solid", "Null"] as const;
+
+  const dimensions =
+    metadata.width && metadata.height
+      ? `${metadata.width} × ${metadata.height}`
+      : "—";
+
+  return (
+    <SectionCard id="analysis-metadata" title={t("title")} subtitle={t("subtitle")}>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <MetricTile
+          label={t("version")}
+          value={metadata.version ?? "—"}
+          hint={metadata.generator ?? undefined}
+        />
+        <MetricTile label={t("dimensions")} value={dimensions} />
+        <MetricTile
+          label={t("frameRate")}
+          value={metadata.frameRate ? `${metadata.frameRate} fps` : "—"}
+        />
+        <MetricTile
+          label={t("totalFrames")}
+          value={
+            metadata.totalFrames !== null ? String(metadata.totalFrames) : "—"
+          }
+          hint={
+            metadata.inPoint !== null && metadata.outPoint !== null
+              ? `${metadata.inPoint} → ${metadata.outPoint}`
+              : undefined
+          }
+        />
+        <MetricTile
+          label={t("duration")}
+          value={formatDuration(metadata.durationSeconds)}
+        />
+        <MetricTile label={t("layerCount")} value={String(metadata.layerCount)} />
+        <MetricTile
+          label={t("assetCount")}
+          value={String(metadata.assetCount)}
+          hint={t("assetBreakdown", {
+            images: metadata.imageAssetCount,
+            precomps: metadata.precompAssetCount,
+          })}
+        />
+        <MetricTile
+          label={t("embeddedImages")}
+          value={String(metadata.embeddedImageCount)}
+          hint={
+            metadata.imageAssetCount > 0
+              ? `${Math.round(
+                  (metadata.embeddedImageCount / metadata.imageAssetCount) * 100,
+                )}%`
+              : undefined
+          }
+        />
+        <MetricTile label={t("markers")} value={String(metadata.markerCount)} />
+        <MetricTile
+          label={t("fileSize")}
+          value={formatFileSize(metadata.fileSizeBytes)}
+        />
+        <MetricTile
+          label={t("is3D")}
+          value={metadata.is3D ? t("yes") : t("no")}
+        />
+      </div>
+
+      <div className="mt-6">
+        <h4 className="mb-2 text-sm font-semibold text-gray-300">
+          {t("layerTypesHeading")}
+        </h4>
+        <div className="flex flex-wrap gap-2">
+          {layerTypes.map((type) => (
+            <span
+              key={type}
+              className="inline-flex items-center gap-1 rounded-full border border-gray-700 bg-gray-900/60 px-3 py-1 text-xs text-gray-300"
+            >
+              <span className="font-medium">{type}</span>
+              <span className="text-gray-500">·</span>
+              <span className="text-white">
+                {metadata.layerCountsByType[type] ?? 0}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/OptimizationSection.tsx
+++ b/src/components/analysis/OptimizationSection.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type {
+  OptimizationSuggestion,
+  SuggestionCode,
+  SuggestionSeverity,
+} from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface OptimizationSectionProps {
+  suggestions: OptimizationSuggestion[];
+  onJumpToLayer: (layerIndex: number) => void;
+}
+
+const SEVERITY_STYLES: Record<SuggestionSeverity, { border: string; dot: string; label: string }> = {
+  info: {
+    border: "border-sky-500/40",
+    dot: "bg-sky-400",
+    label: "bg-sky-500/20 text-sky-200 border-sky-500/40",
+  },
+  warning: {
+    border: "border-amber-500/40",
+    dot: "bg-amber-400",
+    label: "bg-amber-500/20 text-amber-200 border-amber-500/40",
+  },
+  error: {
+    border: "border-rose-500/40",
+    dot: "bg-rose-400",
+    label: "bg-rose-500/20 text-rose-200 border-rose-500/40",
+  },
+};
+
+const CODE_I18N_KEYS: Record<SuggestionCode, string> = {
+  EMBEDDED_IMAGES: "embeddedImages",
+  UNNAMED_LAYERS: "unnamedLayers",
+  EXPRESSIONS: "expressions",
+  HIDDEN_LAYERS: "hiddenLayers",
+  DUPLICATE_SHAPE_PATHS: "duplicateShapePaths",
+  EXCESSIVE_KEYFRAMES: "excessiveKeyframes",
+  LARGE_IMAGE_RESIZE: "largeImageResize",
+  MISSING_MARKERS: "missingMarkers",
+};
+
+export function OptimizationSection({
+  suggestions,
+  onJumpToLayer,
+}: OptimizationSectionProps) {
+  const t = useTranslations("analysis.optimization");
+  const severityRank = { error: 0, warning: 1, info: 2 } as const;
+  const sorted = [...suggestions].sort(
+    (a, b) => severityRank[a.severity] - severityRank[b.severity],
+  );
+
+  return (
+    <SectionCard
+      id="analysis-optimization"
+      title={t("title")}
+      subtitle={t("subtitle", { count: suggestions.length })}
+    >
+      {sorted.length === 0 ? (
+        <p className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+          {t("allClear")}
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {sorted.map((s, idx) => {
+            const style = SEVERITY_STYLES[s.severity];
+            const key = CODE_I18N_KEYS[s.code];
+            return (
+              <li
+                key={`${s.code}-${idx}`}
+                className={`rounded-md border bg-gray-900/50 p-4 ${style.border}`}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${style.dot}`}
+                    aria-hidden
+                  />
+                  <h4 className="text-sm font-semibold text-white">
+                    {t(`codes.${key}.title`)}
+                  </h4>
+                  <span
+                    className={`ml-auto inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${style.label}`}
+                  >
+                    {t(`severity.${s.severity}`)}
+                  </span>
+                  {s.metric !== undefined ? (
+                    <span className="rounded-full border border-gray-700 px-2 py-0.5 text-[10px] text-gray-300">
+                      {t(`codes.${key}.metric`, { value: s.metric })}
+                    </span>
+                  ) : null}
+                </div>
+
+                <dl className="mt-3 space-y-2 text-sm">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-gray-500">
+                      {t("what")}
+                    </dt>
+                    <dd className="text-gray-200">
+                      {t(`codes.${key}.what`)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-gray-500">
+                      {t("why")}
+                    </dt>
+                    <dd className="text-gray-300">
+                      {t(`codes.${key}.why`)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-gray-500">
+                      {t("how")}
+                    </dt>
+                    <dd className="text-gray-300">
+                      {t(`codes.${key}.how`)}
+                    </dd>
+                  </div>
+                </dl>
+
+                {s.relatedLayerIndexes.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <span className="text-[11px] uppercase text-gray-500">
+                      {t("relatedLayers")}
+                    </span>
+                    {s.relatedLayerIndexes.slice(0, 8).map((idx) => (
+                      <button
+                        key={idx}
+                        type="button"
+                        onClick={() => onJumpToLayer(idx)}
+                        className="rounded border border-gray-700 px-2 py-0.5 font-mono text-[11px] text-gray-200 hover:border-yellow-400 hover:text-yellow-200"
+                      >
+                        #{idx}
+                      </button>
+                    ))}
+                    {s.relatedLayerIndexes.length > 8 ? (
+                      <span className="text-[11px] text-gray-500">
+                        +{s.relatedLayerIndexes.length - 8}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/PerformanceSection.tsx
+++ b/src/components/analysis/PerformanceSection.tsx
@@ -50,7 +50,7 @@ export function PerformanceSection({ score }: PerformanceSectionProps) {
           </h4>
           <ul className="space-y-2">
             {sortedBreakdown.map((metric) => {
-              const contributionPct = (metric.contribution / 100) * 100;
+              const contributionPct = metric.score;
               return (
                 <li key={metric.key}>
                   <div className="flex items-center justify-between text-xs">

--- a/src/components/analysis/PerformanceSection.tsx
+++ b/src/components/analysis/PerformanceSection.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { PerformanceGrade, PerformanceScore } from "@/lib/lottie-analyzer";
+import { SectionCard } from "./SectionCard";
+
+interface PerformanceSectionProps {
+  score: PerformanceScore;
+}
+
+const GRADE_COLORS: Record<PerformanceGrade, { ring: string; text: string; bg: string }> = {
+  A: { ring: "ring-emerald-500", text: "text-emerald-300", bg: "bg-emerald-500/10" },
+  B: { ring: "ring-lime-500", text: "text-lime-300", bg: "bg-lime-500/10" },
+  C: { ring: "ring-amber-500", text: "text-amber-300", bg: "bg-amber-500/10" },
+  D: { ring: "ring-orange-500", text: "text-orange-300", bg: "bg-orange-500/10" },
+  F: { ring: "ring-rose-500", text: "text-rose-300", bg: "bg-rose-500/10" },
+};
+
+export function PerformanceSection({ score }: PerformanceSectionProps) {
+  const t = useTranslations("analysis.performance");
+  const colors = GRADE_COLORS[score.grade];
+  const sortedBreakdown = [...score.breakdown].sort(
+    (a, b) => a.contribution - b.contribution,
+  );
+
+  return (
+    <SectionCard
+      id="analysis-performance"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="grid gap-6 md:grid-cols-[200px_1fr]">
+        <div
+          className={`flex flex-col items-center justify-center rounded-xl p-6 ${colors.bg} ring-2 ${colors.ring}`}
+        >
+          <span className={`text-6xl font-black ${colors.text}`}>
+            {score.grade}
+          </span>
+          <span className="mt-2 text-3xl font-bold text-white">
+            {score.score}
+          </span>
+          <span className="mt-1 text-xs uppercase tracking-widest text-gray-400">
+            /100
+          </span>
+        </div>
+
+        <div>
+          <h4 className="mb-3 text-sm font-semibold text-gray-300">
+            {t("breakdownHeading")}
+          </h4>
+          <ul className="space-y-2">
+            {sortedBreakdown.map((metric) => {
+              const contributionPct = (metric.contribution / 100) * 100;
+              return (
+                <li key={metric.key}>
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-gray-300">
+                      {t(`metric.${metric.key}`)}
+                    </span>
+                    <span className="font-mono text-gray-400">
+                      {metric.score}/100 × {Math.round(metric.weight * 100)}% ={" "}
+                      <span className="text-white">
+                        {metric.contribution.toFixed(1)}
+                      </span>
+                    </span>
+                  </div>
+                  <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-gray-800">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-sky-500 to-emerald-500"
+                      style={{ width: `${contributionPct}%` }}
+                    />
+                  </div>
+                  <div className="mt-1 text-[10px] text-gray-500">
+                    {t("rawValue", { value: metric.rawValue })}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analysis/SectionCard.tsx
+++ b/src/components/analysis/SectionCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+interface SectionCardProps {
+  id: string;
+  title: string;
+  subtitle?: string;
+  defaultOpen?: boolean;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export function SectionCard({
+  id,
+  title,
+  subtitle,
+  defaultOpen = true,
+  actions,
+  children,
+}: SectionCardProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const contentId = `${id}-content`;
+
+  return (
+    <section
+      id={id}
+      className="w-full rounded-lg border border-gray-700 bg-gray-800/60 shadow-sm"
+    >
+      <header className="flex items-center justify-between gap-3 px-5 py-4">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex flex-1 items-center justify-between text-left text-white"
+          aria-expanded={open}
+          aria-controls={contentId}
+        >
+          <div>
+            <h3 className="text-lg font-semibold">{title}</h3>
+            {subtitle ? (
+              <p className="mt-1 text-sm text-gray-400">{subtitle}</p>
+            ) : null}
+          </div>
+          <span
+            aria-hidden
+            className={`ml-4 inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-600 text-gray-300 transition-transform ${
+              open ? "rotate-90" : ""
+            }`}
+          >
+            ›
+          </span>
+        </button>
+        {actions ? <div className="flex-shrink-0">{actions}</div> : null}
+      </header>
+      {open ? (
+        <div id={contentId} className="border-t border-gray-700 px-5 py-5">
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/analysis/SnippetSection.tsx
+++ b/src/components/analysis/SnippetSection.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { generateSnippet, type SnippetPlatform } from "@/lib/snippets/generate";
+import { SectionCard } from "./SectionCard";
+
+interface SnippetSectionProps {
+  fileName: string;
+  width: number | null;
+  height: number | null;
+}
+
+const PLATFORMS: SnippetPlatform[] = [
+  "react",
+  "next",
+  "vue",
+  "html",
+  "swift",
+  "kotlin",
+];
+
+function highlight(code: string, language: string): React.ReactNode {
+  const keywordPatterns: Record<string, RegExp> = {
+    tsx: /\b(import|from|export|function|const|let|var|return|async|await|dynamic|default|as|style|true|false|null)\b/g,
+    vue: /\b(script|setup|lang|import|from|template)\b/g,
+    html: /\b(src|background|speed|style|loop|autoplay|script)\b/g,
+    swift: /\b(import|class|final|override|func|let|var|return|true|false|super|init)\b/g,
+    kotlin: /\b(import|val|var|implementation|fun|class)\b/g,
+  };
+  const pattern = keywordPatterns[language];
+  if (!pattern) return code;
+  const parts: (string | { kw: string; idx: number })[] = [];
+  let lastIndex = 0;
+  const globalPattern = new RegExp(pattern.source, "g");
+  let match;
+  let counter = 0;
+  while ((match = globalPattern.exec(code)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(code.slice(lastIndex, match.index));
+    }
+    parts.push({ kw: match[0], idx: counter++ });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < code.length) parts.push(code.slice(lastIndex));
+
+  return parts.map((part, i) =>
+    typeof part === "string" ? (
+      <span key={`t-${i}`}>{part}</span>
+    ) : (
+      <span key={`k-${part.idx}`} className="text-sky-300">
+        {part.kw}
+      </span>
+    ),
+  );
+}
+
+export function SnippetSection({ fileName, width, height }: SnippetSectionProps) {
+  const t = useTranslations("analysis.snippets");
+  const [platform, setPlatform] = useState<SnippetPlatform>("react");
+  const [copied, setCopied] = useState(false);
+
+  const snippet = useMemo(
+    () => generateSnippet(platform, { fileName, width, height }),
+    [platform, fileName, width, height],
+  );
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet.code);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <SectionCard
+      id="analysis-snippets"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="mb-4 flex flex-wrap gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5">
+        {PLATFORMS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPlatform(p)}
+            className={`rounded px-3 py-1 text-xs ${
+              platform === p
+                ? "bg-gray-700 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t(`platforms.${p}`)}
+          </button>
+        ))}
+      </div>
+
+      {snippet.install ? (
+        <div className="mb-2 rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2 font-mono text-xs text-gray-300">
+          <span className="mr-2 text-gray-500">$</span>
+          <span className="whitespace-pre">{snippet.install}</span>
+        </div>
+      ) : null}
+
+      <div className="relative">
+        <pre className="max-h-[420px] overflow-auto rounded-md border border-gray-800 bg-gray-950/80 p-4 font-mono text-xs leading-relaxed text-gray-200">
+          <code>{highlight(snippet.code, snippet.language)}</code>
+        </pre>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="absolute right-3 top-3 rounded border border-gray-700 bg-gray-900/80 px-2 py-1 text-[11px] text-gray-200 hover:bg-gray-800"
+        >
+          {copied ? t("copied") : t("copy")}
+        </button>
+      </div>
+
+      <p className="mt-3 text-[11px] text-gray-500">
+        {t("reflectedContext", {
+          file: fileName,
+          width: width ?? "—",
+          height: height ?? "—",
+        })}
+      </p>
+    </SectionCard>
+  );
+}

--- a/src/components/player/BackgroundSection.tsx
+++ b/src/components/player/BackgroundSection.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { SectionCard } from "@/components/analysis/SectionCard";
+import type { BackgroundValue } from "./types";
+
+interface BackgroundSectionProps {
+  value: BackgroundValue;
+  onChange: (value: BackgroundValue) => void;
+}
+
+interface Preset {
+  id: string;
+  labelKey: string;
+  value: BackgroundValue;
+  previewStyle: React.CSSProperties;
+}
+
+const PRESETS: Preset[] = [
+  {
+    id: "transparent",
+    labelKey: "transparent",
+    value: { kind: "transparent" },
+    previewStyle: {
+      backgroundImage:
+        "linear-gradient(45deg, #bbb 25%, transparent 25%), linear-gradient(-45deg, #bbb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #bbb 75%), linear-gradient(-45deg, transparent 75%, #bbb 75%)",
+      backgroundSize: "10px 10px",
+      backgroundPosition: "0 0, 0 5px, 5px -5px, -5px 0",
+      backgroundColor: "#eee",
+    },
+  },
+  {
+    id: "white",
+    labelKey: "white",
+    value: { kind: "color", color: "#ffffff" },
+    previewStyle: { backgroundColor: "#ffffff" },
+  },
+  {
+    id: "black",
+    labelKey: "black",
+    value: { kind: "color", color: "#000000" },
+    previewStyle: { backgroundColor: "#000000" },
+  },
+  {
+    id: "lightTone1",
+    labelKey: "lightTone1",
+    value: { kind: "color", color: "#f5f5f4" },
+    previewStyle: { backgroundColor: "#f5f5f4" },
+  },
+  {
+    id: "lightTone2",
+    labelKey: "lightTone2",
+    value: { kind: "color", color: "#e0f2fe" },
+    previewStyle: { backgroundColor: "#e0f2fe" },
+  },
+  {
+    id: "darkTone1",
+    labelKey: "darkTone1",
+    value: { kind: "color", color: "#0f172a" },
+    previewStyle: { backgroundColor: "#0f172a" },
+  },
+  {
+    id: "darkTone2",
+    labelKey: "darkTone2",
+    value: { kind: "color", color: "#1f2937" },
+    previewStyle: { backgroundColor: "#1f2937" },
+  },
+];
+
+const RECENT_STORAGE_KEY = "lottieViewer.recentBgColors";
+const MAX_RECENT = 6;
+
+function isValidHex(v: string): boolean {
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(v);
+}
+
+function readRecent(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string" && isValidHex(v));
+  } catch {
+    return [];
+  }
+}
+
+function writeRecent(next: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // localStorage may be unavailable (private mode)
+  }
+}
+
+export function BackgroundSection({ value, onChange }: BackgroundSectionProps) {
+  const t = useTranslations("analysis.background");
+  const [customColor, setCustomColor] = useState<string>(
+    value.kind === "color" ? (value.color ?? "#111111") : "#111111",
+  );
+  const [recent, setRecent] = useState<string[]>([]);
+  const imageUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setRecent(readRecent());
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (imageUrlRef.current) {
+        URL.revokeObjectURL(imageUrlRef.current);
+        imageUrlRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const applyColor = (color: string) => {
+    if (!isValidHex(color)) return;
+    onChange({ kind: "color", color });
+    setRecent((prev) => {
+      const next = [color, ...prev.filter((c) => c.toLowerCase() !== color.toLowerCase())].slice(
+        0,
+        MAX_RECENT,
+      );
+      writeRecent(next);
+      return next;
+    });
+  };
+
+  const handleImage = (file: File) => {
+    const url = URL.createObjectURL(file);
+    if (imageUrlRef.current) {
+      URL.revokeObjectURL(imageUrlRef.current);
+    }
+    imageUrlRef.current = url;
+    onChange({ kind: "image", imageUrl: url });
+  };
+
+  const activePresetId =
+    value.kind === "transparent"
+      ? "transparent"
+      : value.kind === "color"
+        ? PRESETS.find(
+            (p) => p.value.kind === "color" && p.value.color === value.color,
+          )?.id ?? null
+        : null;
+
+  return (
+    <SectionCard
+      id="analysis-background"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="space-y-5">
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("presetsHeading")}
+          </h4>
+          <div className="flex flex-wrap gap-2">
+            {PRESETS.map((preset) => {
+              const active = activePresetId === preset.id;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => onChange(preset.value)}
+                  className={`flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-[11px] ${
+                    active
+                      ? "border-sky-500 text-white"
+                      : "border-gray-700 text-gray-300 hover:border-gray-500"
+                  }`}
+                >
+                  <span
+                    className="h-10 w-10 rounded border border-gray-600"
+                    style={preset.previewStyle}
+                    aria-hidden
+                  />
+                  {t(`presets.${preset.labelKey}`)}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("customColorHeading")}
+          </h4>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              type="color"
+              value={customColor}
+              onChange={(e) => setCustomColor(e.target.value)}
+              className="h-10 w-14 cursor-pointer rounded border border-gray-700 bg-transparent"
+              aria-label={t("customColorPicker")}
+            />
+            <input
+              type="text"
+              value={customColor}
+              onChange={(e) => setCustomColor(e.target.value)}
+              placeholder="#rrggbb"
+              className="w-28 rounded border border-gray-700 bg-gray-900 px-2 py-1 font-mono text-sm text-white"
+              aria-label={t("customColorHex")}
+            />
+            <button
+              type="button"
+              onClick={() => applyColor(customColor)}
+              disabled={!isValidHex(customColor)}
+              className="rounded-md border border-gray-700 bg-gray-900/70 px-3 py-1.5 text-xs text-white hover:bg-gray-800 disabled:opacity-40"
+            >
+              {t("applyColor")}
+            </button>
+          </div>
+
+          {recent.length > 0 ? (
+            <div className="mt-3">
+              <p className="mb-1 text-[11px] uppercase text-gray-500">
+                {t("recentColors")}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {recent.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => applyColor(color)}
+                    className="h-7 w-7 rounded border border-gray-700"
+                    style={{ backgroundColor: color }}
+                    title={color}
+                    aria-label={color}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("customImageHeading")}
+          </h4>
+          <p className="mb-2 text-[11px] text-gray-500">
+            {t("customImageNote")}
+          </p>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleImage(file);
+            }}
+            className="text-xs text-gray-300"
+            aria-label={t("customImageUpload")}
+          />
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/player/LottiePlayerStage.tsx
+++ b/src/components/player/LottiePlayerStage.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import type { AnimationItem, LottiePlayer } from "lottie-web";
+import type { LottieJson } from "@/lib/lottie-analyzer";
+import type { BackgroundValue, LoopMode, PlayerState } from "./types";
+
+export interface LottiePlayerHandle {
+  play: () => void;
+  pause: () => void;
+  goToFrame: (frame: number) => void;
+  stepFrame: (delta: number) => void;
+  isPaused: () => boolean;
+}
+
+interface LottiePlayerStageProps {
+  lottie: LottiePlayer | null;
+  data: LottieJson;
+  state: PlayerState;
+  onFrame: (frame: number) => void;
+  onReady: (totalFrames: number, frameRate: number) => void;
+  onPlayStateChange: (playing: boolean) => void;
+  handleRef: React.RefObject<LottiePlayerHandle | null>;
+}
+
+function backgroundStyle(bg: BackgroundValue): React.CSSProperties {
+  if (bg.kind === "transparent") {
+    return {
+      backgroundImage:
+        "linear-gradient(45deg, #444 25%, transparent 25%), linear-gradient(-45deg, #444 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #444 75%), linear-gradient(-45deg, transparent 75%, #444 75%)",
+      backgroundSize: "20px 20px",
+      backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0",
+      backgroundColor: "#222",
+    };
+  }
+  if (bg.kind === "color") {
+    return { backgroundColor: bg.color ?? "#111" };
+  }
+  if (bg.kind === "image" && bg.imageUrl) {
+    return {
+      backgroundImage: `url(${bg.imageUrl})`,
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+    };
+  }
+  return {};
+}
+
+function mapLoopMode(mode: LoopMode): { loop: boolean } {
+  switch (mode) {
+    case "loop":
+    case "pingpong":
+      return { loop: true };
+    case "once":
+      return { loop: false };
+  }
+}
+
+export function LottiePlayerStage({
+  lottie,
+  data,
+  state,
+  onFrame,
+  onReady,
+  onPlayStateChange,
+  handleRef,
+}: LottiePlayerStageProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<AnimationItem | null>(null);
+  const totalFramesRef = useRef(0);
+
+  useEffect(() => {
+    if (!lottie || !containerRef.current) return;
+
+    if (animationRef.current) {
+      animationRef.current.destroy();
+      animationRef.current = null;
+    }
+
+    containerRef.current.innerHTML = "";
+    const instance = lottie.loadAnimation({
+      container: containerRef.current,
+      renderer: "svg",
+      autoplay: true,
+      animationData: data as unknown as object,
+      ...mapLoopMode(state.loopMode),
+    });
+
+    animationRef.current = instance;
+
+    const handleDomLoaded = () => {
+      const total = instance.totalFrames;
+      const fr = instance.frameRate;
+      totalFramesRef.current = total;
+      onReady(total, fr);
+      onPlayStateChange(!instance.isPaused);
+    };
+
+    const handleEnter = (event: unknown) => {
+      const e = event as { currentTime?: number };
+      if (typeof e?.currentTime === "number") {
+        onFrame(e.currentTime);
+      }
+    };
+
+    const handleComplete = () => {
+      onPlayStateChange(false);
+    };
+
+    const handleLoopComplete = () => {
+      if (state.loopMode === "pingpong") {
+        const current = instance.playDirection;
+        instance.setDirection(current === 1 ? -1 : 1);
+        instance.play();
+      }
+    };
+
+    instance.addEventListener("DOMLoaded", handleDomLoaded);
+    instance.addEventListener("enterFrame", handleEnter);
+    instance.addEventListener("complete", handleComplete);
+    instance.addEventListener("loopComplete", handleLoopComplete);
+
+    return () => {
+      instance.removeEventListener("DOMLoaded", handleDomLoaded);
+      instance.removeEventListener("enterFrame", handleEnter);
+      instance.removeEventListener("complete", handleComplete);
+      instance.removeEventListener("loopComplete", handleLoopComplete);
+      instance.destroy();
+      animationRef.current = null;
+    };
+  }, [
+    lottie,
+    data,
+    state.loopMode,
+    onFrame,
+    onReady,
+    onPlayStateChange,
+  ]);
+
+  useEffect(() => {
+    if (animationRef.current) {
+      animationRef.current.setSpeed(state.speed);
+    }
+  }, [state.speed]);
+
+  useEffect(() => {
+    if (animationRef.current) {
+      animationRef.current.setDirection(state.direction);
+    }
+  }, [state.direction]);
+
+  useEffect(() => {
+    if (!animationRef.current) return;
+    const total = totalFramesRef.current;
+    if (total <= 0) return;
+    if (state.segment) {
+      const from = Math.max(0, Math.min(state.segment.from, total));
+      const to = Math.max(from + 1, Math.min(state.segment.to, total));
+      animationRef.current.playSegments([from, to], true);
+    } else {
+      animationRef.current.playSegments([0, total], true);
+    }
+  }, [state.segment]);
+
+  useImperativeHandle(
+    handleRef,
+    (): LottiePlayerHandle => ({
+      play: () => {
+        animationRef.current?.play();
+        onPlayStateChange(true);
+      },
+      pause: () => {
+        animationRef.current?.pause();
+        onPlayStateChange(false);
+      },
+      goToFrame: (frame: number) => {
+        animationRef.current?.goToAndStop(frame, true);
+        onPlayStateChange(false);
+      },
+      stepFrame: (delta: number) => {
+        if (!animationRef.current) return;
+        const current = animationRef.current.currentFrame;
+        const next = current + delta;
+        animationRef.current.goToAndStop(next, true);
+        onPlayStateChange(false);
+      },
+      isPaused: () => animationRef.current?.isPaused ?? true,
+    }),
+    [onPlayStateChange],
+  );
+
+  const bgStyle = useMemo(() => backgroundStyle(state.background), [state.background]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-96 w-full rounded-lg border border-gray-700"
+      style={bgStyle}
+      role="img"
+    />
+  );
+}

--- a/src/components/player/PlayerControlsSection.tsx
+++ b/src/components/player/PlayerControlsSection.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { SectionCard } from "@/components/analysis/SectionCard";
+import type { LottiePlayerHandle } from "./LottiePlayerStage";
+import type { LoopMode, PlayerState } from "./types";
+
+interface PlayerControlsSectionProps {
+  state: PlayerState;
+  onChange: (partial: Partial<PlayerState>) => void;
+  playerHandle: React.RefObject<LottiePlayerHandle | null>;
+  currentFrame: number;
+  totalFrames: number;
+  frameRate: number;
+  isPlaying: boolean;
+}
+
+const SPEEDS = [0.25, 0.5, 1, 2, 4] as const;
+const LOOP_MODES: LoopMode[] = ["loop", "once", "pingpong"];
+
+export function PlayerControlsSection({
+  state,
+  onChange,
+  playerHandle,
+  currentFrame,
+  totalFrames,
+  frameRate,
+  isPlaying,
+}: PlayerControlsSectionProps) {
+  const t = useTranslations("analysis.playerControls");
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement | null)?.tagName ?? "";
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+      if (e.code === "Space") {
+        e.preventDefault();
+        if (playerHandle.current?.isPaused()) {
+          playerHandle.current?.play();
+        } else {
+          playerHandle.current?.pause();
+        }
+      } else if (e.code === "ArrowLeft") {
+        e.preventDefault();
+        playerHandle.current?.stepFrame(e.shiftKey ? -10 : -1);
+      } else if (e.code === "ArrowRight") {
+        e.preventDefault();
+        playerHandle.current?.stepFrame(e.shiftKey ? 10 : 1);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [playerHandle]);
+
+  const currentSeconds =
+    frameRate > 0 ? (currentFrame / frameRate).toFixed(2) : "0.00";
+  const totalSeconds =
+    frameRate > 0 && totalFrames > 0
+      ? (totalFrames / frameRate).toFixed(2)
+      : "0.00";
+
+  const handleScrub = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    playerHandle.current?.goToFrame(value);
+  };
+
+  const segmentFrom = state.segment?.from ?? 0;
+  const segmentTo = state.segment?.to ?? (totalFrames > 0 ? totalFrames : 0);
+
+  return (
+    <SectionCard
+      id="analysis-player-controls"
+      title={t("title")}
+      subtitle={t("subtitle")}
+    >
+      <div className="space-y-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              if (isPlaying) {
+                playerHandle.current?.pause();
+              } else {
+                playerHandle.current?.play();
+              }
+            }}
+            className="rounded-md border border-gray-700 bg-gray-900/70 px-4 py-1.5 text-sm text-white hover:bg-gray-800"
+          >
+            {isPlaying ? t("pause") : t("play")}
+          </button>
+
+          <div className="flex items-center gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5">
+            {SPEEDS.map((sp) => (
+              <button
+                key={sp}
+                type="button"
+                onClick={() => onChange({ speed: sp })}
+                className={`rounded px-2 py-1 text-xs ${
+                  state.speed === sp
+                    ? "bg-gray-700 text-white"
+                    : "text-gray-400 hover:text-white"
+                }`}
+              >
+                {sp}x
+              </button>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() =>
+              onChange({ direction: state.direction === 1 ? -1 : 1 })
+            }
+            className="rounded-md border border-gray-700 bg-gray-900/70 px-3 py-1.5 text-xs text-white hover:bg-gray-800"
+            aria-label={t("directionToggle")}
+          >
+            {state.direction === 1 ? t("forward") : t("backward")}
+          </button>
+
+          <div className="flex items-center gap-1 rounded-md border border-gray-700 bg-gray-900/60 p-0.5">
+            {LOOP_MODES.map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => onChange({ loopMode: mode })}
+                className={`rounded px-2 py-1 text-xs ${
+                  state.loopMode === mode
+                    ? "bg-gray-700 text-white"
+                    : "text-gray-400 hover:text-white"
+                }`}
+              >
+                {t(`loopMode.${mode}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between text-xs text-gray-400">
+            <span>
+              {t("frame")} <span className="text-white">{Math.round(currentFrame)}</span> /{" "}
+              {totalFrames}
+            </span>
+            <span className="font-mono">
+              {currentSeconds}s / {totalSeconds}s
+            </span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={totalFrames > 0 ? totalFrames : 100}
+            step={1}
+            value={Math.round(currentFrame)}
+            onChange={handleScrub}
+            className="mt-1 w-full accent-sky-500"
+            aria-label={t("scrub")}
+          />
+        </div>
+
+        <fieldset className="rounded-md border border-gray-700 bg-gray-900/40 p-3">
+          <legend className="px-1 text-xs uppercase tracking-wide text-gray-400">
+            {t("segmentLegend")}
+          </legend>
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              <input
+                type="checkbox"
+                checked={state.segment !== null}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onChange({
+                      segment: {
+                        from: 0,
+                        to: Math.max(1, totalFrames),
+                      },
+                    });
+                  } else {
+                    onChange({ segment: null });
+                  }
+                }}
+              />
+              {t("segmentEnable")}
+            </label>
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              {t("from")}
+              <input
+                type="number"
+                min={0}
+                max={totalFrames}
+                value={segmentFrom}
+                disabled={state.segment === null}
+                onChange={(e) =>
+                  onChange({
+                    segment: {
+                      from: Number(e.target.value),
+                      to: segmentTo,
+                    },
+                  })
+                }
+                className="w-20 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-white disabled:opacity-40"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              {t("to")}
+              <input
+                type="number"
+                min={0}
+                max={totalFrames}
+                value={segmentTo}
+                disabled={state.segment === null}
+                onChange={(e) =>
+                  onChange({
+                    segment: {
+                      from: segmentFrom,
+                      to: Number(e.target.value),
+                    },
+                  })
+                }
+                className="w-20 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-white disabled:opacity-40"
+              />
+            </label>
+          </div>
+        </fieldset>
+
+        <p className="text-[11px] text-gray-500">{t("shortcutsHelp")}</p>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/player/types.ts
+++ b/src/components/player/types.ts
@@ -1,0 +1,17 @@
+export type LoopMode = "loop" | "once" | "pingpong";
+
+export type BackgroundKind = "transparent" | "color" | "image";
+
+export interface BackgroundValue {
+  kind: BackgroundKind;
+  color?: string;
+  imageUrl?: string;
+}
+
+export interface PlayerState {
+  speed: number;
+  direction: 1 | -1;
+  loopMode: LoopMode;
+  segment: { from: number; to: number } | null;
+  background: BackgroundValue;
+}

--- a/src/lib/lottie-analyzer/__fixtures__.ts
+++ b/src/lib/lottie-analyzer/__fixtures__.ts
@@ -1,0 +1,150 @@
+import type { LottieJson } from "./types";
+
+export const minimalLottie: LottieJson = {
+  v: "5.7.0",
+  fr: 30,
+  ip: 0,
+  op: 60,
+  w: 512,
+  h: 512,
+  nm: "minimal",
+  ddd: 0,
+  assets: [],
+  layers: [
+    {
+      ty: 4,
+      nm: "Shape 1",
+      ind: 1,
+      ip: 0,
+      op: 60,
+      shapes: [
+        {
+          ty: "sh",
+          ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[0, 0]] }] },
+        },
+      ],
+    },
+  ],
+  meta: { g: "After Effects 22.0" },
+};
+
+export const complexLottie: LottieJson = {
+  v: "5.10.0",
+  fr: 60,
+  ip: 0,
+  op: 180,
+  w: 1920,
+  h: 1080,
+  nm: "complex",
+  ddd: 1,
+  assets: [
+    {
+      id: "image_0",
+      w: 5000,
+      h: 5000,
+      p: "data:image/png;base64,iVBORw0K",
+      e: 1,
+    },
+    {
+      id: "image_1",
+      w: 256,
+      h: 256,
+      p: "image_1.png",
+      e: 0,
+    },
+    {
+      id: "comp_0",
+      layers: [
+        {
+          ty: 4,
+          nm: "Inner Shape",
+          ind: 1,
+          ip: 0,
+          op: 180,
+          shapes: [
+            {
+              ty: "sh",
+              ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[1, 1]] }] },
+            },
+          ],
+          ks: {
+            p: {
+              k: [
+                { t: 0, s: [0] },
+                { t: 30, s: [100] },
+              ],
+              x: "time*100",
+            },
+          },
+        },
+      ],
+    },
+  ],
+  layers: [
+    {
+      ty: 2,
+      nm: "Image Layer",
+      ind: 1,
+      ip: 0,
+      op: 180,
+      refId: "image_0",
+      ddd: 1,
+    },
+    {
+      ty: 4,
+      nm: "Shape Layer 1",
+      ind: 2,
+      ip: 0,
+      op: 180,
+      hd: true,
+      shapes: [
+        {
+          ty: "sh",
+          ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[5, 5]] }] },
+        },
+        {
+          ty: "sh",
+          ks: { k: [{ i: [[0, 0]], o: [[0, 0]], v: [[5, 5]] }] },
+        },
+        { ty: "mm" },
+        { ty: "gs" },
+        { ty: "tm" },
+      ],
+      ef: [{ ty: 1 }, { ty: 2 }],
+      masksProperties: [{ mode: "a" }, { mode: "s" }],
+    },
+    {
+      ty: 5,
+      nm: "Text Layer",
+      ind: 3,
+      ip: 0,
+      op: 180,
+      t: {
+        d: { k: [{ t: 0, s: { t: "hello" } }] },
+        m: { g: 2 },
+        a: [{ foo: 1 }],
+      },
+      tt: 1,
+    },
+  ],
+  markers: [{ tm: 0, cm: "start" }],
+  meta: { g: "After Effects 23.0" },
+};
+
+export const lottieWithUnnamedLayers: LottieJson = {
+  v: "5.7.0",
+  fr: 30,
+  ip: 0,
+  op: 60,
+  w: 512,
+  h: 512,
+  ddd: 0,
+  assets: [],
+  layers: Array.from({ length: 12 }).map((_, i) => ({
+    ty: 4 as const,
+    nm: `Shape Layer ${i + 1}`,
+    ind: i + 1,
+    ip: 0,
+    op: 60,
+  })),
+};

--- a/src/lib/lottie-analyzer/compatibility.test.ts
+++ b/src/lib/lottie-analyzer/compatibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildCompatibility } from "./compatibility";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { extractMetadata } from "./metadata";
+import { scanLottie } from "./scan";
+
+describe("buildCompatibility", () => {
+  function run(data: typeof minimalLottie) {
+    const metadata = extractMetadata(data);
+    const scan = scanLottie(data);
+    return buildCompatibility({ metadata, scan });
+  }
+
+  it("lists the full feature matrix", () => {
+    const result = run(minimalLottie);
+    expect(result.features.map((f) => f.feature)).toEqual([
+      "Expressions",
+      "Merge Paths",
+      "3D Layers",
+      "Mattes",
+      "Gradient Strokes",
+      "Per-character Text",
+      "Trim Path (individually)",
+    ]);
+  });
+
+  it("marks features as detected when present in file", () => {
+    const result = run(complexLottie);
+    const expr = result.features.find((f) => f.feature === "Expressions");
+    const threeD = result.features.find((f) => f.feature === "3D Layers");
+    expect(expr?.detectedInFile).toBe(true);
+    expect(threeD?.detectedInFile).toBe(true);
+  });
+
+  it("computes a summary per platform reflecting worst detected feature", () => {
+    const result = run(complexLottie);
+    expect(result.summary.ios.overall).toBe("unsupported");
+    expect(result.summary.android.overall).toBe("unsupported");
+    expect(result.summary.web.overall === "partial" || result.summary.web.overall === "supported").toBe(true);
+  });
+
+  it("returns 'supported' for every platform on a clean minimal file", () => {
+    const result = run(minimalLottie);
+    expect(result.summary.web.overall).toBe("supported");
+    expect(result.summary.ios.overall).toBe("supported");
+    expect(result.summary.android.overall).toBe("supported");
+  });
+});

--- a/src/lib/lottie-analyzer/compatibility.ts
+++ b/src/lib/lottie-analyzer/compatibility.ts
@@ -1,0 +1,143 @@
+import { DeepScanResult } from "./scan";
+import {
+  LottieMetadata,
+  PlatformCompatibility,
+  PlatformFeatureSupport,
+  PlatformKey,
+  PlatformSupportLevel,
+} from "./types";
+
+interface FeatureDef {
+  feature: string;
+  web: PlatformSupportLevel;
+  ios: PlatformSupportLevel;
+  android: PlatformSupportLevel;
+}
+
+const FEATURE_MATRIX: FeatureDef[] = [
+  {
+    feature: "Expressions",
+    web: "partial",
+    ios: "unsupported",
+    android: "unsupported",
+  },
+  {
+    feature: "Merge Paths",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "3D Layers",
+    web: "partial",
+    ios: "unsupported",
+    android: "unsupported",
+  },
+  {
+    feature: "Mattes",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "Gradient Strokes",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "Per-character Text",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+  {
+    feature: "Trim Path (individually)",
+    web: "supported",
+    ios: "partial",
+    android: "partial",
+  },
+];
+
+function severityRank(level: PlatformSupportLevel): number {
+  if (level === "unsupported") return 2;
+  if (level === "partial") return 1;
+  return 0;
+}
+
+function worstLevel(a: PlatformSupportLevel, b: PlatformSupportLevel): PlatformSupportLevel {
+  return severityRank(a) >= severityRank(b) ? a : b;
+}
+
+interface BuildCompatibilityInput {
+  metadata: LottieMetadata;
+  scan: DeepScanResult;
+}
+
+export function buildCompatibility(
+  input: BuildCompatibilityInput,
+): PlatformCompatibility {
+  const { metadata, scan } = input;
+
+  const detectionMap: Record<string, { detected: boolean; layers: number[] }> = {
+    Expressions: {
+      detected: scan.totalExpressions > 0,
+      layers: Array.from(scan.expressionLayerIndexes),
+    },
+    "Merge Paths": {
+      detected: scan.hasMergePathsLayerIndexes.size > 0,
+      layers: Array.from(scan.hasMergePathsLayerIndexes),
+    },
+    "3D Layers": {
+      detected: metadata.is3D,
+      layers: [],
+    },
+    Mattes: {
+      detected: scan.hasMatteLayerIndexes.size > 0,
+      layers: Array.from(scan.hasMatteLayerIndexes),
+    },
+    "Gradient Strokes": {
+      detected: scan.hasGradientStrokeLayerIndexes.size > 0,
+      layers: Array.from(scan.hasGradientStrokeLayerIndexes),
+    },
+    "Per-character Text": {
+      detected: scan.hasPerCharTextLayerIndexes.size > 0,
+      layers: Array.from(scan.hasPerCharTextLayerIndexes),
+    },
+    "Trim Path (individually)": {
+      detected: scan.hasTrimPathLayerIndexes.size > 0,
+      layers: Array.from(scan.hasTrimPathLayerIndexes),
+    },
+  };
+
+  const features: PlatformFeatureSupport[] = FEATURE_MATRIX.map((def) => {
+    const detection = detectionMap[def.feature];
+    return {
+      feature: def.feature,
+      web: def.web,
+      ios: def.ios,
+      android: def.android,
+      detectedInFile: detection?.detected ?? false,
+      relatedLayerIndexes: detection?.layers ?? [],
+    };
+  });
+
+  const initial: PlatformCompatibility["summary"] = {
+    web: { overall: "supported", unsupportedCount: 0, partialCount: 0 },
+    ios: { overall: "supported", unsupportedCount: 0, partialCount: 0 },
+    android: { overall: "supported", unsupportedCount: 0, partialCount: 0 },
+  };
+
+  const platforms: PlatformKey[] = ["web", "ios", "android"];
+  for (const feature of features) {
+    if (!feature.detectedInFile) continue;
+    for (const platform of platforms) {
+      const level = feature[platform];
+      initial[platform].overall = worstLevel(initial[platform].overall, level);
+      if (level === "unsupported") initial[platform].unsupportedCount += 1;
+      if (level === "partial") initial[platform].partialCount += 1;
+    }
+  }
+
+  return { features, summary: initial };
+}

--- a/src/lib/lottie-analyzer/index.test.ts
+++ b/src/lib/lottie-analyzer/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { analyzeLottie } from "./index";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+
+describe("analyzeLottie", () => {
+  it("returns a combined analysis bundle", () => {
+    const result = analyzeLottie(minimalLottie, { fileSizeBytes: 1024 });
+    expect(result.metadata.fileSizeBytes).toBe(1024);
+    expect(result.layers.layers.length).toBe(1);
+    expect(result.performance.grade).toBe("A");
+    expect(Array.isArray(result.suggestions)).toBe(true);
+    expect(result.compatibility.features.length).toBeGreaterThan(0);
+  });
+
+  it("produces meaningful output on a complex file", () => {
+    const result = analyzeLottie(complexLottie);
+    expect(result.suggestions.length).toBeGreaterThan(0);
+    expect(result.performance.score).toBeLessThan(90);
+    expect(result.compatibility.summary.ios.overall).toBe("unsupported");
+  });
+});

--- a/src/lib/lottie-analyzer/index.ts
+++ b/src/lib/lottie-analyzer/index.ts
@@ -1,0 +1,79 @@
+import { buildCompatibility } from "./compatibility";
+import { analyzeLayers } from "./layers";
+import { extractMetadata } from "./metadata";
+import { buildOptimizationSuggestions } from "./optimization";
+import { computePerformanceScore } from "./performance";
+import { scanLottie } from "./scan";
+import type { LottieAnalysisResult, LottieJson } from "./types";
+
+export interface AnalyzeLottieOptions {
+  fileSizeBytes?: number | null;
+  targetDimensions?: { width: number | null; height: number | null };
+}
+
+export function analyzeLottie(
+  data: LottieJson,
+  options: AnalyzeLottieOptions = {},
+): LottieAnalysisResult {
+  const metadata = extractMetadata(data, {
+    fileSizeBytes: options.fileSizeBytes ?? null,
+  });
+  const layerAnalysis = analyzeLayers(data);
+  const scan = scanLottie(data);
+
+  const totalEffects = layerAnalysis.layers.reduce(
+    (sum, l) => sum + l.effectCount,
+    0,
+  );
+  const totalMasks = layerAnalysis.layers.reduce(
+    (sum, l) => sum + l.maskCount,
+    0,
+  );
+
+  const performance = computePerformanceScore({
+    metadata,
+    scan,
+    totalEffects,
+    totalMasks,
+  });
+
+  const suggestions = buildOptimizationSuggestions({
+    metadata,
+    layers: layerAnalysis.layers,
+    scan,
+    targetDimensions: options.targetDimensions,
+  });
+
+  const compatibility = buildCompatibility({ metadata, scan });
+
+  return {
+    metadata,
+    layers: layerAnalysis,
+    performance,
+    suggestions,
+    compatibility,
+  };
+}
+
+export * from "./types";
+export {
+  extractMetadata,
+  formatDuration,
+  formatFileSize,
+} from "./metadata";
+export { analyzeLayers, getBlendModeName, BLEND_MODE_NAMES } from "./layers";
+export { scanLottie } from "./scan";
+export type { DeepScanResult } from "./scan";
+export {
+  computePerformanceScore,
+  gradeFromScore,
+  scoreLayerCount,
+  scoreExpressions,
+  scoreEffects,
+  scoreMasks,
+  score3D,
+  scoreEmbeddedImages,
+  scoreFrameRate,
+} from "./performance";
+export { buildOptimizationSuggestions } from "./optimization";
+export { buildCompatibility } from "./compatibility";

--- a/src/lib/lottie-analyzer/layers.test.ts
+++ b/src/lib/lottie-analyzer/layers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { analyzeLayers, getBlendModeName } from "./layers";
+
+describe("analyzeLayers", () => {
+  it("produces an analyzed entry for each layer", () => {
+    const result = analyzeLayers(minimalLottie);
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].typeName).toBe("Shape");
+    expect(result.layers[0].isHidden).toBe(false);
+  });
+
+  it("captures effect and mask counts", () => {
+    const result = analyzeLayers(complexLottie);
+    const shape = result.layers.find((l) => l.typeName === "Shape");
+    expect(shape?.effectCount).toBe(2);
+    expect(shape?.maskCount).toBe(2);
+    expect(shape?.isHidden).toBe(true);
+  });
+
+  it("flags 3D layers", () => {
+    const result = analyzeLayers(complexLottie);
+    const image = result.layers.find((l) => l.typeName === "Image");
+    expect(image?.is3D).toBe(true);
+  });
+
+  it("builds a parent-child tree", () => {
+    const data = {
+      ...minimalLottie,
+      layers: [
+        { ty: 3 as const, nm: "Parent", ind: 1, ip: 0, op: 60 },
+        { ty: 4 as const, nm: "Child", ind: 2, ip: 0, op: 60, parent: 1 },
+      ],
+    };
+    const result = analyzeLayers(data);
+    expect(result.tree).toHaveLength(1);
+    expect(result.tree[0].children).toHaveLength(1);
+    expect(result.tree[0].children[0].name).toBe("Child");
+  });
+});
+
+describe("getBlendModeName", () => {
+  it("maps known blend mode codes to names", () => {
+    expect(getBlendModeName(0)).toBe("Normal");
+    expect(getBlendModeName(1)).toBe("Multiply");
+    expect(getBlendModeName(99)).toBe("Mode 99");
+  });
+});

--- a/src/lib/lottie-analyzer/layers.ts
+++ b/src/lib/lottie-analyzer/layers.ts
@@ -1,0 +1,86 @@
+import {
+  AnalyzedLayer,
+  LAYER_TYPE_NAMES,
+  LayerAnalysisResult,
+  LayerTreeNode,
+  LayerTypeCode,
+  LottieJson,
+  LottieLayer,
+} from "./types";
+
+function countMasks(layer: LottieLayer): number {
+  if (Array.isArray(layer.masksProperties)) return layer.masksProperties.length;
+  return 0;
+}
+
+function countEffects(layer: LottieLayer): number {
+  if (Array.isArray(layer.ef)) return layer.ef.length;
+  return 0;
+}
+
+export function analyzeLayers(data: LottieJson): LayerAnalysisResult {
+  const rawLayers: LottieLayer[] = Array.isArray(data.layers) ? data.layers : [];
+
+  const layers: AnalyzedLayer[] = rawLayers.map((layer, idx) => {
+    const typeCode = layer.ty as LayerTypeCode;
+    const typeName = LAYER_TYPE_NAMES[typeCode] ?? `Unknown(${String(typeCode)})`;
+    const name =
+      typeof layer.nm === "string" && layer.nm.length > 0
+        ? layer.nm
+        : `Layer ${idx + 1}`;
+    return {
+      index: typeof layer.ind === "number" ? layer.ind : idx,
+      name,
+      typeCode,
+      typeName,
+      startFrame: typeof layer.ip === "number" ? layer.ip : 0,
+      endFrame: typeof layer.op === "number" ? layer.op : 0,
+      blendMode: typeof layer.bm === "number" ? layer.bm : 0,
+      is3D: layer.ddd === 1,
+      effectCount: countEffects(layer),
+      maskCount: countMasks(layer),
+      parent: typeof layer.parent === "number" ? layer.parent : null,
+      isHidden: layer.hd === true,
+    };
+  });
+
+  const byIndex = new Map<number, LayerTreeNode>();
+  const tree: LayerTreeNode[] = [];
+
+  for (const analyzed of layers) {
+    byIndex.set(analyzed.index, { ...analyzed, children: [] });
+  }
+
+  for (const node of byIndex.values()) {
+    if (node.parent !== null && byIndex.has(node.parent)) {
+      byIndex.get(node.parent)!.children.push(node);
+    } else {
+      tree.push(node);
+    }
+  }
+
+  return { layers, tree };
+}
+
+export const BLEND_MODE_NAMES: Record<number, string> = {
+  0: "Normal",
+  1: "Multiply",
+  2: "Screen",
+  3: "Overlay",
+  4: "Darken",
+  5: "Lighten",
+  6: "Color Dodge",
+  7: "Color Burn",
+  8: "Hard Light",
+  9: "Soft Light",
+  10: "Difference",
+  11: "Exclusion",
+  12: "Hue",
+  13: "Saturation",
+  14: "Color",
+  15: "Luminosity",
+};
+
+export function getBlendModeName(code: number): string {
+  return BLEND_MODE_NAMES[code] ?? `Mode ${code}`;
+}

--- a/src/lib/lottie-analyzer/metadata.test.ts
+++ b/src/lib/lottie-analyzer/metadata.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { extractMetadata, formatDuration, formatFileSize } from "./metadata";
+
+describe("extractMetadata", () => {
+  it("extracts version, generator, dimensions, framerate, duration", () => {
+    const meta = extractMetadata(minimalLottie);
+    expect(meta.version).toBe("5.7.0");
+    expect(meta.generator).toBe("After Effects 22.0");
+    expect(meta.width).toBe(512);
+    expect(meta.height).toBe(512);
+    expect(meta.frameRate).toBe(30);
+    expect(meta.totalFrames).toBe(60);
+    expect(meta.durationSeconds).toBeCloseTo(2, 5);
+  });
+
+  it("counts layers by type and counts assets", () => {
+    const meta = extractMetadata(complexLottie);
+    expect(meta.layerCount).toBe(3);
+    expect(meta.layerCountsByType.Shape).toBe(1);
+    expect(meta.layerCountsByType.Image).toBe(1);
+    expect(meta.layerCountsByType.Text).toBe(1);
+    expect(meta.assetCount).toBe(3);
+    expect(meta.imageAssetCount).toBe(2);
+    expect(meta.precompAssetCount).toBe(1);
+    expect(meta.embeddedImageCount).toBe(1);
+    expect(meta.markerCount).toBe(1);
+  });
+
+  it("detects 3D from ddd flag at root or layer", () => {
+    expect(extractMetadata(complexLottie).is3D).toBe(true);
+    expect(extractMetadata(minimalLottie).is3D).toBe(false);
+  });
+
+  it("returns null fallbacks for missing fields", () => {
+    const meta = extractMetadata({});
+    expect(meta.version).toBeNull();
+    expect(meta.width).toBeNull();
+    expect(meta.height).toBeNull();
+    expect(meta.frameRate).toBeNull();
+    expect(meta.totalFrames).toBeNull();
+    expect(meta.durationSeconds).toBeNull();
+    expect(meta.layerCount).toBe(0);
+    expect(meta.assetCount).toBe(0);
+    expect(meta.is3D).toBe(false);
+  });
+
+  it("accepts fileSizeBytes option", () => {
+    const meta = extractMetadata(minimalLottie, { fileSizeBytes: 2048 });
+    expect(meta.fileSizeBytes).toBe(2048);
+  });
+});
+
+describe("formatters", () => {
+  it("formats duration", () => {
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(2.345)).toBe("2.35s");
+    expect(formatDuration(30)).toBe("30.0s");
+  });
+
+  it("formats file size", () => {
+    expect(formatFileSize(null)).toBe("—");
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(2048)).toBe("2.0 KB");
+    expect(formatFileSize(5 * 1024 * 1024)).toBe("5.00 MB");
+  });
+});

--- a/src/lib/lottie-analyzer/metadata.ts
+++ b/src/lib/lottie-analyzer/metadata.ts
@@ -1,0 +1,132 @@
+import {
+  LAYER_TYPE_NAMES,
+  LayerTypeCode,
+  LottieJson,
+  LottieLayer,
+  LottieMetadata,
+} from "./types";
+
+const DEFAULT_COUNTS: Record<string, number> = Object.values(LAYER_TYPE_NAMES).reduce(
+  (acc, name) => {
+    acc[name] = 0;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+
+function collectAllLayers(data: LottieJson): LottieLayer[] {
+  const result: LottieLayer[] = [];
+  const rootLayers = Array.isArray(data.layers) ? data.layers : [];
+  for (const layer of rootLayers) {
+    result.push(layer);
+  }
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  for (const asset of assets) {
+    if (Array.isArray(asset.layers)) {
+      for (const layer of asset.layers) {
+        result.push(layer);
+      }
+    }
+  }
+  return result;
+}
+
+function countEmbeddedImages(data: LottieJson): number {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  let count = 0;
+  for (const asset of assets) {
+    const isImage = typeof asset.p === "string" && asset.p.length > 0;
+    if (!isImage) continue;
+    const isEmbedded =
+      asset.e === 1 ||
+      (typeof asset.p === "string" && asset.p.startsWith("data:"));
+    if (isEmbedded) count += 1;
+  }
+  return count;
+}
+
+function countImageAssets(data: LottieJson): number {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  return assets.filter((a) => typeof a.p === "string" && a.p.length > 0).length;
+}
+
+function countPrecompAssets(data: LottieJson): number {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  return assets.filter((a) => Array.isArray(a.layers)).length;
+}
+
+function detect3D(data: LottieJson): boolean {
+  if (data.ddd === 1) return true;
+  const layers = collectAllLayers(data);
+  return layers.some((l) => l.ddd === 1);
+}
+
+function countLayersByType(layers: LottieLayer[]): Record<string, number> {
+  const counts: Record<string, number> = { ...DEFAULT_COUNTS };
+  for (const layer of layers) {
+    const typeCode = layer.ty as LayerTypeCode;
+    const typeName = LAYER_TYPE_NAMES[typeCode];
+    if (typeName) {
+      counts[typeName] += 1;
+    }
+  }
+  return counts;
+}
+
+export interface ExtractMetadataOptions {
+  fileSizeBytes?: number | null;
+}
+
+export function extractMetadata(
+  data: LottieJson,
+  options: ExtractMetadataOptions = {},
+): LottieMetadata {
+  const rootLayers = Array.isArray(data.layers) ? data.layers : [];
+  const ip = typeof data.ip === "number" ? data.ip : null;
+  const op = typeof data.op === "number" ? data.op : null;
+  const fr = typeof data.fr === "number" ? data.fr : null;
+
+  let totalFrames: number | null = null;
+  let duration: number | null = null;
+  if (ip !== null && op !== null) {
+    totalFrames = Math.max(0, op - ip);
+    if (fr && fr > 0) {
+      duration = totalFrames / fr;
+    }
+  }
+
+  return {
+    version: typeof data.v === "string" ? data.v : null,
+    generator: typeof data.meta?.g === "string" ? data.meta.g : null,
+    width: typeof data.w === "number" ? data.w : null,
+    height: typeof data.h === "number" ? data.h : null,
+    frameRate: fr,
+    inPoint: ip,
+    outPoint: op,
+    totalFrames,
+    durationSeconds: duration,
+    layerCount: rootLayers.length,
+    layerCountsByType: countLayersByType(rootLayers),
+    assetCount: Array.isArray(data.assets) ? data.assets.length : 0,
+    imageAssetCount: countImageAssets(data),
+    precompAssetCount: countPrecompAssets(data),
+    embeddedImageCount: countEmbeddedImages(data),
+    markerCount: Array.isArray(data.markers) ? data.markers.length : 0,
+    fileSizeBytes:
+      typeof options.fileSizeBytes === "number" ? options.fileSizeBytes : null,
+    is3D: detect3D(data),
+  };
+}
+
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds)) return "—";
+  if (seconds < 10) return `${seconds.toFixed(2)}s`;
+  return `${seconds.toFixed(1)}s`;
+}
+
+export function formatFileSize(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes)) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/src/lib/lottie-analyzer/optimization.test.ts
+++ b/src/lib/lottie-analyzer/optimization.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  complexLottie,
+  lottieWithUnnamedLayers,
+  minimalLottie,
+} from "./__fixtures__";
+import { analyzeLayers } from "./layers";
+import { extractMetadata } from "./metadata";
+import { buildOptimizationSuggestions } from "./optimization";
+import { scanLottie } from "./scan";
+import type { SuggestionCode } from "./types";
+
+function codes(data: typeof minimalLottie): SuggestionCode[] {
+  const metadata = extractMetadata(data);
+  const layers = analyzeLayers(data);
+  const scan = scanLottie(data);
+  return buildOptimizationSuggestions({
+    metadata,
+    layers: layers.layers,
+    scan,
+  }).map((s) => s.code);
+}
+
+describe("buildOptimizationSuggestions", () => {
+  it("detects embedded images, expressions, hidden layers, duplicates, matte/gradient/trim assets on a complex file", () => {
+    const result = codes(complexLottie);
+    expect(result).toContain("EMBEDDED_IMAGES");
+    expect(result).toContain("EXPRESSIONS");
+    expect(result).toContain("HIDDEN_LAYERS");
+    expect(result).toContain("DUPLICATE_SHAPE_PATHS");
+    expect(result).toContain("LARGE_IMAGE_RESIZE");
+  });
+
+  it("flags unnamed default-name layers", () => {
+    const result = codes(lottieWithUnnamedLayers);
+    expect(result).toContain("UNNAMED_LAYERS");
+    expect(result).toContain("MISSING_MARKERS");
+  });
+
+  it("does not over-report on a minimal clean file", () => {
+    const result = codes(minimalLottie);
+    expect(result).not.toContain("EMBEDDED_IMAGES");
+    expect(result).not.toContain("EXPRESSIONS");
+    expect(result).not.toContain("HIDDEN_LAYERS");
+    expect(result).not.toContain("LARGE_IMAGE_RESIZE");
+  });
+
+  it("attaches related layer indexes for hidden/expression detections", () => {
+    const metadata = extractMetadata(complexLottie);
+    const layers = analyzeLayers(complexLottie);
+    const scan = scanLottie(complexLottie);
+    const suggestions = buildOptimizationSuggestions({
+      metadata,
+      layers: layers.layers,
+      scan,
+    });
+    const hidden = suggestions.find((s) => s.code === "HIDDEN_LAYERS");
+    expect(hidden?.relatedLayerIndexes.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/lottie-analyzer/optimization.ts
+++ b/src/lib/lottie-analyzer/optimization.ts
@@ -1,0 +1,162 @@
+import { DeepScanResult } from "./scan";
+import { AnalyzedLayer, LottieMetadata, OptimizationSuggestion } from "./types";
+
+const UNNAMED_DEFAULT_PATTERN = /^(Layer \d+|Shape Layer \d+|Null \d+|Solid \d+|새 컴포지션 \d+|컴포지션 \d+)$/u;
+
+const LARGE_IMAGE_THRESHOLD_PX = 2000;
+
+interface BuildSuggestionsInput {
+  metadata: LottieMetadata;
+  layers: AnalyzedLayer[];
+  scan: DeepScanResult;
+  targetDimensions?: { width: number | null; height: number | null };
+}
+
+export function buildOptimizationSuggestions(
+  input: BuildSuggestionsInput,
+): OptimizationSuggestion[] {
+  const { metadata, layers, scan } = input;
+  const suggestions: OptimizationSuggestion[] = [];
+  const targetW = input.targetDimensions?.width ?? metadata.width;
+  const targetH = input.targetDimensions?.height ?? metadata.height;
+
+  const embeddedRatio =
+    metadata.imageAssetCount > 0
+      ? metadata.embeddedImageCount / metadata.imageAssetCount
+      : 0;
+  if (metadata.embeddedImageCount > 0) {
+    suggestions.push({
+      code: "EMBEDDED_IMAGES",
+      severity: embeddedRatio >= 0.5 ? "warning" : "info",
+      what: "embeddedImages.what",
+      why: "embeddedImages.why",
+      how: "embeddedImages.how",
+      relatedLayerIndexes: [],
+      relatedAssetIds: Array.from(scan.assetStats.entries())
+        .filter(([, v]) => v.embedded)
+        .map(([id]) => id),
+      metric: metadata.embeddedImageCount,
+    });
+  }
+
+  const unnamedLayers = layers.filter((l) =>
+    UNNAMED_DEFAULT_PATTERN.test(l.name.trim()),
+  );
+  if (unnamedLayers.length > 0) {
+    suggestions.push({
+      code: "UNNAMED_LAYERS",
+      severity: unnamedLayers.length >= 10 ? "warning" : "info",
+      what: "unnamedLayers.what",
+      why: "unnamedLayers.why",
+      how: "unnamedLayers.how",
+      relatedLayerIndexes: unnamedLayers.map((l) => l.index),
+      relatedAssetIds: [],
+      metric: unnamedLayers.length,
+    });
+  }
+
+  if (scan.totalExpressions > 0) {
+    suggestions.push({
+      code: "EXPRESSIONS",
+      severity: scan.totalExpressions >= 5 ? "warning" : "info",
+      what: "expressions.what",
+      why: "expressions.why",
+      how: "expressions.how",
+      relatedLayerIndexes: Array.from(scan.expressionLayerIndexes),
+      relatedAssetIds: [],
+      metric: scan.totalExpressions,
+    });
+  }
+
+  const hiddenLayers = layers.filter((l) => l.isHidden);
+  if (hiddenLayers.length > 0) {
+    suggestions.push({
+      code: "HIDDEN_LAYERS",
+      severity: "info",
+      what: "hiddenLayers.what",
+      why: "hiddenLayers.why",
+      how: "hiddenLayers.how",
+      relatedLayerIndexes: hiddenLayers.map((l) => l.index),
+      relatedAssetIds: [],
+      metric: hiddenLayers.length,
+    });
+  }
+
+  if (scan.totalDuplicateShapePaths > 0) {
+    suggestions.push({
+      code: "DUPLICATE_SHAPE_PATHS",
+      severity: "info",
+      what: "duplicateShapePaths.what",
+      why: "duplicateShapePaths.why",
+      how: "duplicateShapePaths.how",
+      relatedLayerIndexes: Array.from(scan.duplicateShapePathLayerIndexes),
+      relatedAssetIds: [],
+      metric: scan.totalDuplicateShapePaths,
+    });
+  }
+
+  const excessiveKeyframeLayers: number[] = [];
+  let totalExcessive = 0;
+  for (const [idx, count] of scan.keyframeCountByLayer.entries()) {
+    if (count >= 100) {
+      excessiveKeyframeLayers.push(idx);
+      totalExcessive += count;
+    }
+  }
+  if (excessiveKeyframeLayers.length > 0 || scan.totalKeyframes >= 500) {
+    suggestions.push({
+      code: "EXCESSIVE_KEYFRAMES",
+      severity:
+        scan.totalKeyframes >= 1000 || excessiveKeyframeLayers.length >= 5
+          ? "warning"
+          : "info",
+      what: "excessiveKeyframes.what",
+      why: "excessiveKeyframes.why",
+      how: "excessiveKeyframes.how",
+      relatedLayerIndexes: excessiveKeyframeLayers,
+      relatedAssetIds: [],
+      metric: totalExcessive > 0 ? totalExcessive : scan.totalKeyframes,
+    });
+  }
+
+  const oversizedAssets: string[] = [];
+  for (const [id, stats] of scan.assetStats.entries()) {
+    if (!stats.width || !stats.height) continue;
+    if (!targetW || !targetH) {
+      if (stats.width >= LARGE_IMAGE_THRESHOLD_PX || stats.height >= LARGE_IMAGE_THRESHOLD_PX) {
+        oversizedAssets.push(id);
+      }
+      continue;
+    }
+    if (stats.width > targetW * 2 || stats.height > targetH * 2) {
+      oversizedAssets.push(id);
+    }
+  }
+  if (oversizedAssets.length > 0) {
+    suggestions.push({
+      code: "LARGE_IMAGE_RESIZE",
+      severity: "warning",
+      what: "largeImageResize.what",
+      why: "largeImageResize.why",
+      how: "largeImageResize.how",
+      relatedLayerIndexes: [],
+      relatedAssetIds: oversizedAssets,
+      metric: oversizedAssets.length,
+    });
+  }
+
+  if (metadata.markerCount === 0 && metadata.totalFrames && metadata.totalFrames > 0) {
+    suggestions.push({
+      code: "MISSING_MARKERS",
+      severity: "info",
+      what: "missingMarkers.what",
+      why: "missingMarkers.why",
+      how: "missingMarkers.how",
+      relatedLayerIndexes: [],
+      relatedAssetIds: [],
+      metric: 0,
+    });
+  }
+
+  return suggestions;
+}

--- a/src/lib/lottie-analyzer/performance.test.ts
+++ b/src/lib/lottie-analyzer/performance.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { complexLottie, minimalLottie } from "./__fixtures__";
+import { extractMetadata } from "./metadata";
+import {
+  computePerformanceScore,
+  gradeFromScore,
+  scoreEmbeddedImages,
+  scoreExpressions,
+  scoreFrameRate,
+  scoreLayerCount,
+} from "./performance";
+import { scanLottie } from "./scan";
+import { analyzeLayers } from "./layers";
+
+describe("scoring primitives", () => {
+  it("decreases score as layer count grows", () => {
+    expect(scoreLayerCount(5)).toBe(100);
+    expect(scoreLayerCount(50)).toBe(70);
+    expect(scoreLayerCount(200)).toBe(10);
+  });
+
+  it("penalizes expressions", () => {
+    expect(scoreExpressions(0)).toBe(100);
+    expect(scoreExpressions(3)).toBe(80);
+    expect(scoreExpressions(30)).toBe(10);
+  });
+
+  it("penalizes embedded images (linear)", () => {
+    expect(scoreEmbeddedImages(0)).toBe(100);
+    expect(scoreEmbeddedImages(5)).toBeCloseTo(50, 5);
+    expect(scoreEmbeddedImages(10)).toBe(0);
+  });
+
+  it("penalizes very high framerates", () => {
+    expect(scoreFrameRate(24)).toBe(100);
+    expect(scoreFrameRate(60)).toBe(70);
+    expect(scoreFrameRate(240)).toBe(20);
+  });
+
+  it("grades scores correctly", () => {
+    expect(gradeFromScore(95)).toBe("A");
+    expect(gradeFromScore(80)).toBe("B");
+    expect(gradeFromScore(65)).toBe("C");
+    expect(gradeFromScore(50)).toBe("D");
+    expect(gradeFromScore(10)).toBe("F");
+  });
+});
+
+describe("computePerformanceScore", () => {
+  function score(data: typeof minimalLottie) {
+    const metadata = extractMetadata(data);
+    const layers = analyzeLayers(data);
+    const scan = scanLottie(data);
+    const totalEffects = layers.layers.reduce((s, l) => s + l.effectCount, 0);
+    const totalMasks = layers.layers.reduce((s, l) => s + l.maskCount, 0);
+    return computePerformanceScore({ metadata, scan, totalEffects, totalMasks });
+  }
+
+  it("gives a high score to a minimal file", () => {
+    const result = score(minimalLottie);
+    expect(result.score).toBeGreaterThanOrEqual(90);
+    expect(result.grade).toBe("A");
+    expect(result.breakdown).toHaveLength(7);
+  });
+
+  it("gives a worse score to a heavy file", () => {
+    const result = score(complexLottie);
+    expect(result.score).toBeLessThan(score(minimalLottie).score);
+  });
+
+  it("breakdown contributions sum roughly to the score", () => {
+    const result = score(complexLottie);
+    const total = result.breakdown.reduce((s, m) => s + m.contribution, 0);
+    expect(Math.round(total)).toBe(result.score);
+  });
+});

--- a/src/lib/lottie-analyzer/performance.ts
+++ b/src/lib/lottie-analyzer/performance.ts
@@ -1,0 +1,168 @@
+import { DeepScanResult } from "./scan";
+import {
+  LottieMetadata,
+  PerformanceGrade,
+  PerformanceMetricBreakdown,
+  PerformanceScore,
+} from "./types";
+
+interface MetricInput {
+  key: string;
+  weight: number;
+  rawValue: number;
+  score: number;
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function linearInverseScore(value: number, worstAt: number): number {
+  if (value <= 0) return 100;
+  if (value >= worstAt) return 0;
+  return clamp(100 - (value / worstAt) * 100, 0, 100);
+}
+
+export function scoreLayerCount(count: number): number {
+  if (count <= 10) return 100;
+  if (count <= 30) return 85;
+  if (count <= 60) return 70;
+  if (count <= 100) return 50;
+  if (count <= 150) return 30;
+  return 10;
+}
+
+export function scoreExpressions(totalExpressions: number): number {
+  if (totalExpressions === 0) return 100;
+  if (totalExpressions <= 3) return 80;
+  if (totalExpressions <= 10) return 55;
+  if (totalExpressions <= 25) return 30;
+  return 10;
+}
+
+export function scoreEffects(totalEffects: number): number {
+  if (totalEffects === 0) return 100;
+  if (totalEffects <= 3) return 80;
+  if (totalEffects <= 8) return 55;
+  if (totalEffects <= 15) return 30;
+  return 10;
+}
+
+export function scoreMasks(totalMasks: number): number {
+  if (totalMasks === 0) return 100;
+  if (totalMasks <= 3) return 85;
+  if (totalMasks <= 8) return 60;
+  if (totalMasks <= 15) return 35;
+  return 15;
+}
+
+export function score3D(is3D: boolean): number {
+  return is3D ? 40 : 100;
+}
+
+export function scoreEmbeddedImages(count: number): number {
+  return linearInverseScore(count, 10);
+}
+
+export function scoreFrameRate(fr: number | null): number {
+  if (fr === null) return 70;
+  if (fr <= 24) return 100;
+  if (fr <= 30) return 95;
+  if (fr <= 60) return 70;
+  if (fr <= 120) return 40;
+  return 20;
+}
+
+export function gradeFromScore(score: number): PerformanceGrade {
+  if (score >= 90) return "A";
+  if (score >= 75) return "B";
+  if (score >= 60) return "C";
+  if (score >= 45) return "D";
+  return "F";
+}
+
+const WEIGHTS = {
+  layerCount: 0.2,
+  expressions: 0.2,
+  effects: 0.15,
+  masks: 0.15,
+  is3D: 0.1,
+  embeddedImages: 0.1,
+  frameRate: 0.1,
+};
+
+export interface ScorePerformanceInput {
+  metadata: LottieMetadata;
+  scan: DeepScanResult;
+  totalEffects: number;
+  totalMasks: number;
+}
+
+export function computePerformanceScore(input: ScorePerformanceInput): PerformanceScore {
+  const { metadata, scan, totalEffects, totalMasks } = input;
+
+  const metrics: MetricInput[] = [
+    {
+      key: "layerCount",
+      weight: WEIGHTS.layerCount,
+      rawValue: metadata.layerCount,
+      score: scoreLayerCount(metadata.layerCount),
+    },
+    {
+      key: "expressions",
+      weight: WEIGHTS.expressions,
+      rawValue: scan.totalExpressions,
+      score: scoreExpressions(scan.totalExpressions),
+    },
+    {
+      key: "effects",
+      weight: WEIGHTS.effects,
+      rawValue: totalEffects,
+      score: scoreEffects(totalEffects),
+    },
+    {
+      key: "masks",
+      weight: WEIGHTS.masks,
+      rawValue: totalMasks,
+      score: scoreMasks(totalMasks),
+    },
+    {
+      key: "is3D",
+      weight: WEIGHTS.is3D,
+      rawValue: metadata.is3D ? 1 : 0,
+      score: score3D(metadata.is3D),
+    },
+    {
+      key: "embeddedImages",
+      weight: WEIGHTS.embeddedImages,
+      rawValue: metadata.embeddedImageCount,
+      score: scoreEmbeddedImages(metadata.embeddedImageCount),
+    },
+    {
+      key: "frameRate",
+      weight: WEIGHTS.frameRate,
+      rawValue: metadata.frameRate ?? 0,
+      score: scoreFrameRate(metadata.frameRate),
+    },
+  ];
+
+  let total = 0;
+  const breakdown: PerformanceMetricBreakdown[] = metrics.map((m) => {
+    const contribution = m.score * m.weight;
+    total += contribution;
+    return {
+      key: m.key,
+      weight: m.weight,
+      rawValue: m.rawValue,
+      score: m.score,
+      contribution,
+    };
+  });
+
+  const finalScore = Math.round(total);
+  return {
+    score: finalScore,
+    grade: gradeFromScore(finalScore),
+    breakdown,
+  };
+}

--- a/src/lib/lottie-analyzer/scan.ts
+++ b/src/lib/lottie-analyzer/scan.ts
@@ -1,0 +1,215 @@
+import {
+  LottieAsset,
+  LottieJson,
+  LottieLayer,
+  LottieShape,
+} from "./types";
+
+export interface DeepScanResult {
+  expressionLayerIndexes: Set<number>;
+  totalExpressions: number;
+  keyframeCountByLayer: Map<number, number>;
+  totalKeyframes: number;
+  duplicateShapePathLayerIndexes: Set<number>;
+  totalDuplicateShapePaths: number;
+  layerTextMap: Map<number, boolean>;
+  hasMergePathsLayerIndexes: Set<number>;
+  hasGradientStrokeLayerIndexes: Set<number>;
+  hasTrimPathLayerIndexes: Set<number>;
+  hasMatteLayerIndexes: Set<number>;
+  hasPerCharTextLayerIndexes: Set<number>;
+  assetStats: Map<string, { width: number | null; height: number | null; embedded: boolean }>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function countKeyframes(value: unknown): number {
+  if (!isPlainObject(value)) return 0;
+  const record = value as Record<string, unknown>;
+  if (Array.isArray(record.k) && record.k.length > 1 && isPlainObject(record.k[0])) {
+    return record.k.length;
+  }
+  return 0;
+}
+
+function walkForExpressionsAndKeyframes(
+  node: unknown,
+  layerIdx: number,
+  result: DeepScanResult,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walkForExpressionsAndKeyframes(item, layerIdx, result);
+    }
+    return;
+  }
+  if (!isPlainObject(node)) return;
+
+  const record = node as Record<string, unknown>;
+
+  if (typeof record.x === "string" && record.x.length > 0) {
+    result.expressionLayerIndexes.add(layerIdx);
+    result.totalExpressions += 1;
+  }
+
+  const kfCount = countKeyframes(record);
+  if (kfCount > 0) {
+    const prev = result.keyframeCountByLayer.get(layerIdx) ?? 0;
+    result.keyframeCountByLayer.set(layerIdx, prev + kfCount);
+    result.totalKeyframes += kfCount;
+  }
+
+  for (const key of Object.keys(record)) {
+    walkForExpressionsAndKeyframes(record[key], layerIdx, result);
+  }
+}
+
+function collectShapePaths(shapes: LottieShape[] | undefined, out: string[]): void {
+  if (!Array.isArray(shapes)) return;
+  for (const shape of shapes) {
+    if (!shape || typeof shape !== "object") continue;
+    if (shape.ty === "sh" && shape.ks) {
+      try {
+        out.push(JSON.stringify(shape.ks));
+      } catch {
+        // ignore circular structure
+      }
+    }
+    if (Array.isArray(shape.it)) {
+      collectShapePaths(shape.it as LottieShape[], out);
+    }
+  }
+}
+
+function detectDuplicateShapePaths(layer: LottieLayer): number {
+  if (!Array.isArray(layer.shapes)) return 0;
+  const paths: string[] = [];
+  collectShapePaths(layer.shapes, paths);
+  if (paths.length < 2) return 0;
+  const seen = new Map<string, number>();
+  let duplicates = 0;
+  for (const p of paths) {
+    const n = (seen.get(p) ?? 0) + 1;
+    seen.set(p, n);
+    if (n >= 2) duplicates += 1;
+  }
+  return duplicates;
+}
+
+function detectFeaturesFromShapes(
+  shapes: LottieShape[] | undefined,
+  detected: {
+    mergePaths: boolean;
+    gradientStroke: boolean;
+    trimPath: boolean;
+  },
+): void {
+  if (!Array.isArray(shapes)) return;
+  for (const shape of shapes) {
+    if (!shape || typeof shape !== "object") continue;
+    if (shape.ty === "mm") detected.mergePaths = true;
+    if (shape.ty === "gs") detected.gradientStroke = true;
+    if (shape.ty === "tm") detected.trimPath = true;
+    if (Array.isArray(shape.it)) {
+      detectFeaturesFromShapes(shape.it as LottieShape[], detected);
+    }
+  }
+}
+
+function detectPerCharText(layer: LottieLayer): boolean {
+  if (layer.ty !== 5) return false;
+  const t = layer.t as Record<string, unknown> | undefined;
+  if (!isPlainObject(t)) return false;
+  const m = t.m as Record<string, unknown> | undefined;
+  if (!isPlainObject(m)) return false;
+  const g = m.g;
+  if (typeof g === "number" && g > 1) return true;
+  const a = t.a;
+  if (Array.isArray(a) && a.length > 0) return true;
+  return false;
+}
+
+function detectMatte(layer: LottieLayer): boolean {
+  if (typeof layer.tt === "number" && layer.tt > 0) return true;
+  if (typeof layer.td === "number" && layer.td > 0) return true;
+  return false;
+}
+
+function collectAssetStats(
+  data: LottieJson,
+  result: DeepScanResult,
+): void {
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  for (const asset of assets) {
+    if (!asset.id) continue;
+    const isImage = typeof asset.p === "string" && asset.p.length > 0;
+    if (!isImage) continue;
+    const embedded =
+      asset.e === 1 ||
+      (typeof asset.p === "string" && asset.p.startsWith("data:"));
+    result.assetStats.set(asset.id, {
+      width: typeof asset.w === "number" ? asset.w : null,
+      height: typeof asset.h === "number" ? asset.h : null,
+      embedded,
+    });
+  }
+}
+
+export function scanLottie(data: LottieJson): DeepScanResult {
+  const result: DeepScanResult = {
+    expressionLayerIndexes: new Set<number>(),
+    totalExpressions: 0,
+    keyframeCountByLayer: new Map<number, number>(),
+    totalKeyframes: 0,
+    duplicateShapePathLayerIndexes: new Set<number>(),
+    totalDuplicateShapePaths: 0,
+    layerTextMap: new Map<number, boolean>(),
+    hasMergePathsLayerIndexes: new Set<number>(),
+    hasGradientStrokeLayerIndexes: new Set<number>(),
+    hasTrimPathLayerIndexes: new Set<number>(),
+    hasMatteLayerIndexes: new Set<number>(),
+    hasPerCharTextLayerIndexes: new Set<number>(),
+    assetStats: new Map(),
+  };
+
+  const layers: LottieLayer[] = Array.isArray(data.layers) ? data.layers : [];
+  const precompAssets: LottieAsset[] = Array.isArray(data.assets)
+    ? data.assets.filter((a) => Array.isArray(a.layers))
+    : [];
+
+  const allLayers: LottieLayer[] = [...layers];
+  for (const asset of precompAssets) {
+    if (Array.isArray(asset.layers)) allLayers.push(...asset.layers);
+  }
+
+  for (let i = 0; i < allLayers.length; i += 1) {
+    const layer = allLayers[i];
+    const layerIdx = typeof layer.ind === "number" ? layer.ind : i;
+
+    walkForExpressionsAndKeyframes(layer, layerIdx, result);
+
+    const dupCount = detectDuplicateShapePaths(layer);
+    if (dupCount > 0) {
+      result.duplicateShapePathLayerIndexes.add(layerIdx);
+      result.totalDuplicateShapePaths += dupCount;
+    }
+
+    const features = {
+      mergePaths: false,
+      gradientStroke: false,
+      trimPath: false,
+    };
+    detectFeaturesFromShapes(layer.shapes, features);
+    if (features.mergePaths) result.hasMergePathsLayerIndexes.add(layerIdx);
+    if (features.gradientStroke) result.hasGradientStrokeLayerIndexes.add(layerIdx);
+    if (features.trimPath) result.hasTrimPathLayerIndexes.add(layerIdx);
+
+    if (detectMatte(layer)) result.hasMatteLayerIndexes.add(layerIdx);
+    if (detectPerCharText(layer)) result.hasPerCharTextLayerIndexes.add(layerIdx);
+  }
+
+  collectAssetStats(data, result);
+  return result;
+}

--- a/src/lib/lottie-analyzer/types.ts
+++ b/src/lib/lottie-analyzer/types.ts
@@ -1,0 +1,216 @@
+export type LayerTypeCode = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export const LAYER_TYPE_NAMES: Record<LayerTypeCode, string> = {
+  0: "Precomp",
+  1: "Solid",
+  2: "Image",
+  3: "Null",
+  4: "Shape",
+  5: "Text",
+  6: "Audio",
+};
+
+export interface LottieAsset {
+  id?: string;
+  w?: number;
+  h?: number;
+  u?: string;
+  p?: string;
+  e?: number;
+  layers?: LottieLayer[];
+  [key: string]: unknown;
+}
+
+export interface LottieMarker {
+  tm?: number;
+  cm?: string;
+  dr?: number;
+  [key: string]: unknown;
+}
+
+export interface LottieLayerTransform {
+  p?: { k?: unknown } | unknown;
+  a?: { k?: unknown } | unknown;
+  s?: { k?: unknown } | unknown;
+  r?: { k?: unknown } | unknown;
+  o?: { k?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface LottieShape {
+  ty?: string;
+  it?: LottieShape[];
+  ks?: { k?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface LottieLayerEffect {
+  ty?: number;
+  nm?: string;
+  [key: string]: unknown;
+}
+
+export interface LottieLayerMask {
+  mode?: string;
+  [key: string]: unknown;
+}
+
+export interface LottieLayer {
+  ty: LayerTypeCode;
+  nm?: string;
+  ind?: number;
+  parent?: number;
+  ip?: number;
+  op?: number;
+  st?: number;
+  sr?: number;
+  bm?: number;
+  ddd?: 0 | 1;
+  hd?: boolean;
+  ks?: LottieLayerTransform;
+  shapes?: LottieShape[];
+  ef?: LottieLayerEffect[];
+  masksProperties?: LottieLayerMask[];
+  hasMask?: boolean;
+  refId?: string;
+  t?: { d?: unknown; m?: unknown; p?: unknown } | unknown;
+  [key: string]: unknown;
+}
+
+export interface LottieJson {
+  v?: string;
+  fr?: number;
+  ip?: number;
+  op?: number;
+  w?: number;
+  h?: number;
+  nm?: string;
+  ddd?: 0 | 1;
+  assets?: LottieAsset[];
+  layers?: LottieLayer[];
+  markers?: LottieMarker[];
+  meta?: {
+    g?: string;
+    a?: string;
+    k?: string;
+    d?: string;
+    tc?: string;
+    [key: string]: unknown;
+  };
+  chars?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface LottieMetadata {
+  version: string | null;
+  generator: string | null;
+  width: number | null;
+  height: number | null;
+  frameRate: number | null;
+  inPoint: number | null;
+  outPoint: number | null;
+  totalFrames: number | null;
+  durationSeconds: number | null;
+  layerCount: number;
+  layerCountsByType: Record<string, number>;
+  assetCount: number;
+  imageAssetCount: number;
+  precompAssetCount: number;
+  embeddedImageCount: number;
+  markerCount: number;
+  fileSizeBytes: number | null;
+  is3D: boolean;
+}
+
+export interface AnalyzedLayer {
+  index: number;
+  name: string;
+  typeCode: LayerTypeCode;
+  typeName: string;
+  startFrame: number;
+  endFrame: number;
+  blendMode: number;
+  is3D: boolean;
+  effectCount: number;
+  maskCount: number;
+  parent: number | null;
+  isHidden: boolean;
+}
+
+export interface LayerTreeNode extends AnalyzedLayer {
+  children: LayerTreeNode[];
+}
+
+export interface LayerAnalysisResult {
+  layers: AnalyzedLayer[];
+  tree: LayerTreeNode[];
+}
+
+export type PerformanceGrade = "A" | "B" | "C" | "D" | "F";
+
+export interface PerformanceMetricBreakdown {
+  key: string;
+  weight: number;
+  rawValue: number;
+  score: number;
+  contribution: number;
+}
+
+export interface PerformanceScore {
+  score: number;
+  grade: PerformanceGrade;
+  breakdown: PerformanceMetricBreakdown[];
+}
+
+export type SuggestionSeverity = "info" | "warning" | "error";
+
+export type SuggestionCode =
+  | "EMBEDDED_IMAGES"
+  | "UNNAMED_LAYERS"
+  | "EXPRESSIONS"
+  | "HIDDEN_LAYERS"
+  | "DUPLICATE_SHAPE_PATHS"
+  | "EXCESSIVE_KEYFRAMES"
+  | "LARGE_IMAGE_RESIZE"
+  | "MISSING_MARKERS";
+
+export interface OptimizationSuggestion {
+  code: SuggestionCode;
+  severity: SuggestionSeverity;
+  what: string;
+  why: string;
+  how: string;
+  relatedLayerIndexes: number[];
+  relatedAssetIds: string[];
+  metric?: number;
+}
+
+export type PlatformKey = "web" | "ios" | "android";
+
+export type PlatformSupportLevel = "supported" | "partial" | "unsupported";
+
+export interface PlatformFeatureSupport {
+  feature: string;
+  web: PlatformSupportLevel;
+  ios: PlatformSupportLevel;
+  android: PlatformSupportLevel;
+  detectedInFile: boolean;
+  relatedLayerIndexes: number[];
+}
+
+export interface PlatformCompatibility {
+  features: PlatformFeatureSupport[];
+  summary: Record<PlatformKey, {
+    overall: PlatformSupportLevel;
+    unsupportedCount: number;
+    partialCount: number;
+  }>;
+}
+
+export interface LottieAnalysisResult {
+  metadata: LottieMetadata;
+  layers: LayerAnalysisResult;
+  performance: PerformanceScore;
+  suggestions: OptimizationSuggestion[];
+  compatibility: PlatformCompatibility;
+}

--- a/src/lib/snippets/generate.test.ts
+++ b/src/lib/snippets/generate.test.ts
@@ -38,10 +38,22 @@ describe("generateSnippet", () => {
     expect(out.code).toContain("CGRect(x: 0, y: 0, width: 400, height: 300)");
   });
 
-  it("produces kotlin snippet with R.raw lookup", () => {
+  it("produces kotlin snippet with a valid Android resource identifier", () => {
     const out = generateSnippet("kotlin", input);
-    expect(out.code).toContain("R.raw.my-lottie");
-    expect(out.code).toContain("my_lottie");
+    expect(out.code).toContain("R.raw.my_lottie");
+    expect(out.code).toContain("res/raw/my_lottie.json");
+    expect(out.code).not.toContain("R.raw.my-lottie");
+    expect(out.code).not.toMatch(/R\.raw\.[^a-z0-9_]/);
+  });
+
+  it("kotlin snippet normalizes numeric-leading and whitespace filenames", () => {
+    const out = generateSnippet("kotlin", {
+      fileName: "123 cool.json",
+      width: null,
+      height: null,
+    });
+    expect(out.code).toMatch(/R\.raw\.[a-z_][a-z0-9_]*/);
+    expect(out.code).not.toMatch(/R\.raw\.[^a-z0-9_\n]/);
   });
 
   it("handles missing dimensions and unusual filenames", () => {

--- a/src/lib/snippets/generate.test.ts
+++ b/src/lib/snippets/generate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { generateSnippet } from "./generate";
+
+const input = { fileName: "my-lottie.json", width: 400, height: 300 };
+
+describe("generateSnippet", () => {
+  it("produces react snippet with install command and dimensions", () => {
+    const out = generateSnippet("react", input);
+    expect(out.language).toBe("tsx");
+    expect(out.install).toContain("lottie-react");
+    expect(out.code).toContain('import my_lottie from "./my-lottie.json"');
+    expect(out.code).toContain("width: 400, height: 300");
+  });
+
+  it("produces next snippet with dynamic ssr false", () => {
+    const out = generateSnippet("next", input);
+    expect(out.code).toContain("\"use client\"");
+    expect(out.code).toContain("dynamic(() => import(\"lottie-react\")");
+  });
+
+  it("produces vue snippet with Vue3Lottie", () => {
+    const out = generateSnippet("vue", input);
+    expect(out.language).toBe("vue");
+    expect(out.code).toContain("Vue3Lottie");
+    expect(out.code).toContain(":width=\"400\"");
+  });
+
+  it("produces html snippet without install command", () => {
+    const out = generateSnippet("html", input);
+    expect(out.install).toBeNull();
+    expect(out.code).toContain("<lottie-player");
+    expect(out.code).toContain("width: 400px; height: 300px");
+  });
+
+  it("produces swift snippet stripping extension", () => {
+    const out = generateSnippet("swift", input);
+    expect(out.code).toContain("LottieAnimationView(name: \"my-lottie\")");
+    expect(out.code).toContain("CGRect(x: 0, y: 0, width: 400, height: 300)");
+  });
+
+  it("produces kotlin snippet with R.raw lookup", () => {
+    const out = generateSnippet("kotlin", input);
+    expect(out.code).toContain("R.raw.my-lottie");
+    expect(out.code).toContain("my_lottie");
+  });
+
+  it("handles missing dimensions and unusual filenames", () => {
+    const out = generateSnippet("html", {
+      fileName: "123 cool.json",
+      width: null,
+      height: null,
+    });
+    expect(out.code).toContain("width: 100%; height: 100%");
+    const swift = generateSnippet("swift", {
+      fileName: "no-ext",
+      width: null,
+      height: null,
+    });
+    expect(swift.code).toContain("LottieAnimationView(name: \"no-ext\")");
+  });
+});

--- a/src/lib/snippets/generate.ts
+++ b/src/lib/snippets/generate.ts
@@ -1,0 +1,167 @@
+export type SnippetPlatform =
+  | "react"
+  | "vue"
+  | "next"
+  | "html"
+  | "swift"
+  | "kotlin";
+
+export interface SnippetInput {
+  fileName: string;
+  width: number | null;
+  height: number | null;
+}
+
+export interface SnippetOutput {
+  platform: SnippetPlatform;
+  language: "tsx" | "vue" | "html" | "swift" | "kotlin";
+  install: string | null;
+  code: string;
+}
+
+function safeVar(fileName: string): string {
+  const base = fileName.replace(/\.[^.]+$/, "");
+  const cleaned = base.replace(/[^a-zA-Z0-9]+/g, "_");
+  const trimmed = cleaned.replace(/^_+|_+$/g, "");
+  if (!trimmed) return "animation";
+  if (/^[0-9]/.test(trimmed)) return `_${trimmed}`;
+  return trimmed;
+}
+
+function dimensionStyle(width: number | null, height: number | null): string {
+  if (width && height) return `width: ${width}px; height: ${height}px`;
+  return "width: 100%; height: 100%";
+}
+
+export function generateSnippet(
+  platform: SnippetPlatform,
+  input: SnippetInput,
+): SnippetOutput {
+  const varName = safeVar(input.fileName);
+  const w = input.width ?? 300;
+  const h = input.height ?? 300;
+
+  switch (platform) {
+    case "react":
+      return {
+        platform,
+        language: "tsx",
+        install: "npm install lottie-react",
+        code: `import Lottie from "lottie-react";
+import ${varName} from "./${input.fileName}";
+
+export function ${capitalize(varName)}Animation() {
+  return <Lottie animationData={${varName}} style={{ width: ${w}, height: ${h} }} loop />;
+}
+`,
+      };
+    case "next":
+      return {
+        platform,
+        language: "tsx",
+        install: "npm install lottie-react",
+        code: `"use client";
+
+import dynamic from "next/dynamic";
+import ${varName} from "./${input.fileName}";
+
+const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
+
+export function ${capitalize(varName)}Animation() {
+  return <Lottie animationData={${varName}} style={{ width: ${w}, height: ${h} }} loop />;
+}
+`,
+      };
+    case "vue":
+      return {
+        platform,
+        language: "vue",
+        install: "npm install vue3-lottie",
+        code: `<script setup lang="ts">
+import { Vue3Lottie } from "vue3-lottie";
+import ${varName} from "./${input.fileName}";
+</script>
+
+<template>
+  <Vue3Lottie :animationData="${varName}" :width="${w}" :height="${h}" loop />
+</template>
+`,
+      };
+    case "html":
+      return {
+        platform,
+        language: "html",
+        install: null,
+        code: `<script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+<lottie-player
+  src="./${input.fileName}"
+  background="transparent"
+  speed="1"
+  style="${dimensionStyle(input.width, input.height)}"
+  loop
+  autoplay
+></lottie-player>
+`,
+      };
+    case "swift":
+      return {
+        platform,
+        language: "swift",
+        install:
+          "// Swift Package Manager\n// https://github.com/airbnb/lottie-ios",
+        code: `import Lottie
+import UIKit
+
+final class ${capitalize(varName)}ViewController: UIViewController {
+  private let animationView = LottieAnimationView(name: "${stripExtension(
+    input.fileName,
+  )}")
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    animationView.frame = CGRect(x: 0, y: 0, width: ${w}, height: ${h})
+    animationView.contentMode = .scaleAspectFit
+    animationView.loopMode = .loop
+    view.addSubview(animationView)
+    animationView.play()
+  }
+}
+`,
+      };
+    case "kotlin":
+      return {
+        platform,
+        language: "kotlin",
+        install:
+          "// build.gradle(.kts)\n// implementation(\"com.airbnb.android:lottie:6.5.2\")",
+        code: `// res/raw/${stripExtension(input.fileName)}.json 에 파일을 배치
+// layout XML
+/*
+<com.airbnb.lottie.LottieAnimationView
+    android:id="@+id/${varName}"
+    android:layout_width="${w}dp"
+    android:layout_height="${h}dp"
+    app:lottie_rawRes="@raw/${stripExtension(input.fileName)}"
+    app:lottie_autoPlay="true"
+    app:lottie_loop="true" />
+*/
+
+import com.airbnb.lottie.LottieAnimationView
+
+val animationView: LottieAnimationView = findViewById(R.id.${varName})
+animationView.setAnimation(R.raw.${stripExtension(input.fileName)})
+animationView.repeatCount = LottieDrawable.INFINITE
+animationView.playAnimation()
+`,
+      };
+  }
+}
+
+function capitalize(v: string): string {
+  if (!v) return v;
+  return v.charAt(0).toUpperCase() + v.slice(1);
+}
+
+function stripExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, "");
+}

--- a/src/lib/snippets/generate.ts
+++ b/src/lib/snippets/generate.ts
@@ -128,32 +128,36 @@ final class ${capitalize(varName)}ViewController: UIViewController {
 }
 `,
       };
-    case "kotlin":
+    case "kotlin": {
+      const resName = varName.toLowerCase();
       return {
         platform,
         language: "kotlin",
         install:
           "// build.gradle(.kts)\n// implementation(\"com.airbnb.android:lottie:6.5.2\")",
-        code: `// res/raw/${stripExtension(input.fileName)}.json 에 파일을 배치
+        code: `// Android 리소스 이름은 [a-z0-9_]만 허용됩니다.
+// 원본 파일(${input.fileName})을 res/raw/${resName}.json 으로 저장하세요.
 // layout XML
 /*
 <com.airbnb.lottie.LottieAnimationView
-    android:id="@+id/${varName}"
+    android:id="@+id/${resName}"
     android:layout_width="${w}dp"
     android:layout_height="${h}dp"
-    app:lottie_rawRes="@raw/${stripExtension(input.fileName)}"
+    app:lottie_rawRes="@raw/${resName}"
     app:lottie_autoPlay="true"
     app:lottie_loop="true" />
 */
 
 import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.LottieDrawable
 
-val animationView: LottieAnimationView = findViewById(R.id.${varName})
-animationView.setAnimation(R.raw.${stripExtension(input.fileName)})
+val animationView: LottieAnimationView = findViewById(R.id.${resName})
+animationView.setAnimation(R.raw.${resName})
 animationView.repeatCount = LottieDrawable.INFINITE
 animationView.playAnimation()
 `,
       };
+    }
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## 📌 Summary

> JSO-1 (AdSense 승인을 위한 Lottie 분석 도구 고도화) Phase A~D를 프로덕션(main)으로 릴리즈한다.

## 📋 Changes

- 포함된 daily 통합 PR: #26 (daily/2026-04-20 → dev)
- 포함된 feature PR:
  - #22 feature/JSO-1-phase-a-analyzer-utils — `src/lib/lottie-analyzer/` 분석 유틸 모듈 + vitest 30
  - #23 feature/JSO-1-phase-b-sections-1-5 — Section 1~5 분석 UI
  - #24 feature/JSO-1-phase-c-sections-6-8 — Section 6~8 (재생 컨트롤/배경/코드 스니펫) + Kotlin 리소스 식별자 수정
  - #25 feature/JSO-1-phase-d-common — 호환 패널 HTML/a11y 수정, 성능 바 재조정, 다크 테마 고정

## 🧠 Context & Background

AdSense \"Thin Content\" 거절 대응. 업로드 후 화면을 \"자동 생성 분석 콘텐츠 + 재생 컨트롤 + 배경 전환 + 코드 스니펫\"으로 확장. 프로덕션 배포 → 최소 2주 안정 운영 → Search Console 사이트맵 재제출 → AdSense 재심사 요청 흐름의 첫 단계.

## ✅ How to Test

- 각 feature PR에서 Momus 리뷰 및 vitest 38/38, tsc, ESLint, next build clean 검증 완료.
- 프로덕션 배포 후: `https://<프로덕션 도메인>/` → Lottie JSON 업로드 → 뷰어 + 재생/배경 섹션 + 5개 분석 섹션 + 코드 스니펫 섹션 자동 렌더 확인.
- 모바일(375px)에서 호환 매트릭스 가로 스크롤, 플레이어 컨트롤 wrap, 섹션 세로 스택 확인.

## 🔗 Related Issues

- Related: JSO-1 (Phase A~D 구현 완료, 배포 및 재심사 단계 시작)